### PR TITLE
fix(plays-and-hits): totals, date reset and cache invalidation after ticket creation

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed - 2026-04-07
+
+#### bet — aggregates no se devolvían en modo agrupado
+- **`bet/controller/bet.controller.ts`**: En el path `grouped=true`, para `page === 1` ahora también llama a `repository.getTotalAmount` y `repository.getTotalPrize` en paralelo e incluye `aggregates: { totalAmount, totalPrize }` en la respuesta. Antes el campo `aggregates` era `undefined`, lo que causaba que el frontend mostrara los totales en blanco al recargar la página en modo agrupado.
+
 ### Fixed - 2026-04-04
 
 #### current-account — grupo sin pasadores mostraba todos

--- a/api/src/bet/controller/bet.controller.ts
+++ b/api/src/bet/controller/bet.controller.ts
@@ -59,6 +59,30 @@ export class BetController {
         const totalCount = page === 1 ? count : 0;
         const totalPages = page === 1 ? Math.ceil(count / limit) : 0;
         const hasMore = page === 1 ? page < totalPages : parsedBets.length >= limit;
+
+        let aggregates: { totalAmount?: number; totalPrize?: number } = {};
+        if (page === 1) {
+          const [totalAmount, totalPrize] = await Promise.all([
+            this.repository.getTotalAmount({
+              date,
+              schedule_id,
+              cashier_id,
+              lottery_id,
+              organization_ids,
+              group_user_ids,
+            }),
+            this.repository.getTotalPrize({
+              date,
+              schedule_id,
+              cashier_id,
+              lottery_id,
+              organization_ids,
+              group_user_ids,
+            }),
+          ]);
+          aggregates = { totalAmount, totalPrize };
+        }
+
         return {
           data: parsedBets,
           pagination: {
@@ -68,6 +92,7 @@ export class BetController {
             totalPages,
             hasMore,
           },
+          aggregates,
         };
       } else {
         // Con paginación

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed - 2026-04-07
+
+#### plays-and-hits — totales vacíos en modo agrupado al recargar
+- **`features/plays-and-hits/plays-and-hits-table.tsx`**: Elimina la guarda `if (grouped === 'false' || !grouped)` del `useEffect` que llama `onTotalsUpdate`. Ahora siempre propaga los agregados (ya que el API también los devuelve en modo agrupado — ver API CHANGELOG).
+
+#### plays-and-hits — no cargaban jugadas al volver desde el aside
+- **`features/plays-and-hits/header-play-and-hits.tsx`**: Cambia el dep array del `useLayoutEffect` de `[]` a `[date]`. Con `[]`, si el componente ya estaba montado y la navegación SPA limpiaba los search params (sin `date`), el efecto no se re-ejecutaba y la fecha nunca se re-inicializaba. Con `[date]`, se re-ejecuta cada vez que `date` desaparece de la URL.
+
+#### make-plays — jugadas y tickets no se actualizaban al crear un ticket
+- **`hooks/mutations/tickets/useTicket.ts`**: `onSuccess` ahora también invalida `['bets-infinite']` y `['tickets-infinite']`, forzando el refresh de plays-and-hits y terminal-ticket al crear un ticket.
+- **`hooks/mutations/tickets/useEditTicket.ts`**: Ídem para edición de tickets.
+
 ### Changed - 2026-04-04
 
 #### filter-section — botón Buscar para filtrar por pasador

--- a/web/src/features/plays-and-hits/header-play-and-hits.tsx
+++ b/web/src/features/plays-and-hits/header-play-and-hits.tsx
@@ -7,16 +7,17 @@ import { useSearchParams } from 'react-router-dom';
 const HeaderPlayAndHits = () => {
   const today = dayjs();
   const [searchParams, setSearchParams] = useSearchParams();
+  const date = searchParams.get('date');
 
-  // Inicializar fecha solo si no está ya en la URL — evita render extra con useEffect
+  // Inicializar fecha si no está en la URL — también re-ejecuta al volver a la página sin params
   useLayoutEffect(() => {
-    if (!searchParams.get('date')) {
+    if (!date) {
       const params = new URLSearchParams(searchParams);
       params.set('date', today.format('YYYY-MM-DD'));
       setSearchParams(params, { replace: true });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [date]);
 
   const handleDayChange = (date?: string) => {
     const params = new URLSearchParams(searchParams);

--- a/web/src/features/plays-and-hits/plays-and-hits-table.tsx
+++ b/web/src/features/plays-and-hits/plays-and-hits-table.tsx
@@ -78,13 +78,11 @@ const PlaysAndHitsTable: React.FC<Props> = ({ onTotalsUpdate }) => {
     totalItems: bets.length,
   });
 
-  // Actualizar totales cuando cambian los datos
+  // Actualizar totales cuando cambian los datos (grouped o individual)
   useEffect(() => {
-    if (grouped === 'false' || !grouped) {
-      const agg = data?.pages?.[0]?.aggregates;
-      onTotalsUpdate?.(toFinite(agg?.totalAmount, 0), toFinite(agg?.totalPrize, 0));
-    }
-  }, [data, grouped, onTotalsUpdate]);
+    const agg = data?.pages?.[0]?.aggregates;
+    onTotalsUpdate?.(toFinite(agg?.totalAmount, 0), toFinite(agg?.totalPrize, 0));
+  }, [data, onTotalsUpdate]);
 
   if (isLoading) {
     return (

--- a/web/src/hooks/mutations/tickets/useEditTicket.ts
+++ b/web/src/hooks/mutations/tickets/useEditTicket.ts
@@ -24,6 +24,8 @@ export const useEditTicket = () => {
         exact: false,
         refetchType: 'active',
       });
+      queryClient.invalidateQueries({ queryKey: ['bets-infinite'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['tickets-infinite'], exact: false });
     },
   });
 };

--- a/web/src/hooks/mutations/tickets/useTicket.ts
+++ b/web/src/hooks/mutations/tickets/useTicket.ts
@@ -17,6 +17,8 @@ export const useCreateTicket = () => {
     mutationFn: createTicket,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tickets'] });
+      queryClient.invalidateQueries({ queryKey: ['bets-infinite'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['tickets-infinite'], exact: false });
     },
   });
 };


### PR DESCRIPTION
- [API] bet.controller: compute and return aggregates (totalAmount/totalPrize) in grouped path for page 1 — they were missing, causing blank totals on reload
- [Web] plays-and-hits-table: remove grouped guard from onTotalsUpdate effect so totals propagate regardless of grouping mode
- [Web] header-play-and-hits: change useLayoutEffect deps from [] to [date] so the date is re-initialized when navigating back to the page via the aside
- [Web] useCreateTicket / useEditTicket: also invalidate bets-infinite and tickets-infinite caches on success so plays-and-hits and terminal-ticket refresh automatically after a ticket is saved from make-plays