### PR TITLE
fix(make-plays): prevent duplicate ticket creation and fix stale chunk errors

### DIFF
--- a/web/src/features/make-plays/provider/MakePlaysProvider.tsx
+++ b/web/src/features/make-plays/provider/MakePlaysProvider.tsx
@@ -131,6 +131,10 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
   const betsRef = useRef(bets);
   useEffect(() => { betsRef.current = bets; }, [bets]);
 
+  // Mutex: prevents duplicate ticket creation from rapid double-clicks / Enter key.
+  // useRef updates synchronously unlike useState, so the guard works within the same event.
+  const isSubmittingRef = useRef(false);
+
   // Auto-clean closed-schedule bets every 10s for CASHIERs
   useEffect(() => {
     if (user?.user_type !== USER_TYPE.CASHIER) return;
@@ -163,6 +167,8 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
   );
 
   const handleCreateBet = useCallback(() => {
+    if (isSubmittingRef.current) return;
+
     // Solo validar schedules cerrados para cashiers
     if (user?.user_type === USER_TYPE.CASHIER) {
       const closed = detectClosedSchedules(bets);
@@ -173,6 +179,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
       }
     }
 
+    isSubmittingRef.current = true;
     setIsEnabledCreateBet(false);
     const today = dayjs().format('YYYY-MM-DD');
 
@@ -226,6 +233,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
           toast.error('Ocurrió un error, intente de nuevo');
         },
         onSettled: () => {
+          isSubmittingRef.current = false;
           setIsEnabledCreateBet(true);
         },
       });
@@ -250,6 +258,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
             toast.error('Ocurrió un error al modificar el ticket, intente de nuevo');
           },
           onSettled: () => {
+            isSubmittingRef.current = false;
             setIsEnabledCreateBet(true);
           },
         }
@@ -312,6 +321,8 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
     }
 
     // Proceder con el cierre del ticket
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
     setIsEnabledCreateBet(false);
     const today = dayjs().format('YYYY-MM-DD');
 
@@ -332,7 +343,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
           };
 
           if (user?.user_type === USER_TYPE.CASHIER) {
-            const { blob, fileName } = makeTicketPdf(lastTicket);
+            const { blob, fileName } = await makeTicketPdf(lastTicket);
             const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
             try {
@@ -365,6 +376,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
           toast.error('Ocurrió un error, intente de nuevo');
         },
         onSettled: () => {
+          isSubmittingRef.current = false;
           setIsEnabledCreateBet(true);
         },
       });
@@ -389,6 +401,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
             toast.error('Ocurrió un error al modificar el ticket, intente de nuevo');
           },
           onSettled: () => {
+            isSubmittingRef.current = false;
             setIsEnabledCreateBet(true);
           },
         }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,4 +8,12 @@ import { injectSpeedInsights } from '@vercel/speed-insights';
 injectSpeedInsights();
 inject()
 
+// Reload once when a dynamic import fails due to stale chunk hashes after a new deploy.
+window.addEventListener('vite:preloadError', () => {
+  if (!sessionStorage.getItem('chunk-reload')) {
+    sessionStorage.setItem('chunk-reload', '1');
+    window.location.reload();
+  }
+});
+
 createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
- Add isSubmittingRef mutex in MakePlaysProvider to block concurrent ticket creation from rapid double-clicks or Enter key; ref updates synchronously unlike setState so the guard fires before any re-render
- Fix missing await on makeTicketPdf in handleConfirmClosedSchedules — blob and fileName were undefined, breaking PDF generation in the closed-schedule path
- Add vite:preloadError handler in main.tsx to auto-reload once when stale chunk hashes cause MIME-type errors after a new deployment