### PR TITLE
perf(session): replace per-request DB ops with in-memory cache + SSE

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added - 2026-04-07
+
+#### Session — cache en memoria + SSE para eliminar DB ops por request
+
+- **`session/cache/session.cache.ts`** (nuevo): Singleton `SessionCache`. Evita el DB read de sesión en cada request autenticado. Cache miss → DB read → popula el cache. Incluye `getSessionIdsByUserId` para limpiar todas las sesiones de un usuario en logout-all.
+- **`session/cache/session-activity.cache.ts`** (nuevo): Singleton `SessionActivityCache`. Bufferiza las actualizaciones de `last_activity_at` y `expires_at` en memoria. El monitor job las flushea a DB cada 30 minutos en un único batch query.
+- **`session/sse/session-sse.manager.ts`** (nuevo): Singleton `SessionSSEManager`. Mantiene las conexiones SSE abiertas. Pushea `session_expired` cuando una sesión es revocada o expira, eliminando el polling periódico del frontend.
+- **`session/job/session-monitor.job.ts`** (nuevo): Job en background que corre cada 30 min. Flushea el `ActivityCache` → re-lee sesiones desde DB → expira sesiones inválidas via SSE → pingea conexiones para detectar las muertas. Exporta `flushActivityCache()` para el SIGTERM handler.
+- **`supabase/migrations/20260407120000_batch_update_session_activity.sql`** (nuevo): Función `batch_update_session_activity` — actualiza N sesiones en un único `UPDATE ... FROM UNNEST(...)`. Reemplaza N queries individuales por 1.
+
+#### Session — endpoints y comportamiento
+
+- **`auth/route/auth.route.ts`**: Agrega `GET /api/private/auth/stream` — endpoint SSE pasivo que no extiende el sliding window.
+- **`auth/route/auth.route.ts`**: `POST /api/login` ahora incluye `organization_id` en la respuesta, eliminando el round-trip a `/validate` post-login.
+- **`middlewares/auth.middleware.ts`**: Reescrito para usar `SessionCache` y `ActivityCache`. Cache hit → 0 DB reads de sesión. Solo endpoints reales (no `/validate`, no `/stream`) actualizan el sliding window. Cache miss → 1 DB read para poblar el cache.
+- **`auth/controller/auth.controller.ts`**: `logoutSession` ahora limpia ambos caches y pushea el evento SSE inmediatamente, sin esperar al monitor job.
+- **`session/repository/session.repository.ts`**: Agrega `getBatchByIds` y `batchUpdateActivity` (usa RPC).
+- **`index.ts`**: Arranca `startSessionMonitorJob()` al iniciar el servidor. Agrega handler `SIGTERM` que flushea el `ActivityCache` antes de cerrar.
+
 ### Fixed - 2026-04-07
 
 #### bet — aggregates no se devolvían en modo agrupado

--- a/api/middlewares/auth.middleware.ts
+++ b/api/middlewares/auth.middleware.ts
@@ -7,6 +7,8 @@ import { SessionRepository } from 'api/src/session/repository/session.repository
 import { AuthRepository } from 'api/src/auth/repository/auth.repository';
 import { parseUser } from 'api/src/user/helper/parseUser';
 import { SESSION_CONFIG } from 'api/src/config/session.config';
+import { sessionCache } from 'api/src/session/cache/session.cache';
+import { activityCache } from 'api/src/session/cache/session-activity.cache';
 
 // Extend Express Request interface to include session info
 declare module 'express' {
@@ -23,16 +25,17 @@ declare module 'express' {
 const sessionRepository = new SessionRepository();
 const authRepository = new AuthRepository();
 
+// Endpoints that don't count as user activity (passive checks)
+const PASSIVE_PATHS = ['/auth/validate', '/auth/stream'];
+
 /**
- * Session-based authentication middleware
- * Validates JWT access token and session in database with sliding window
+ * Session-based authentication middleware.
  *
- * Features:
- * - Validates access token JWT
- * - Checks session in database (is_active, expires_at)
- * - Updates last_activity_at (sliding window: 4 hours)
- * - Gets fresh user data from database
- * - Attaches user and organization_id to request
+ * Uses two in-memory caches to eliminate per-request DB writes:
+ * - SessionCache: avoids DB reads on cache hit
+ * - ActivityCache: buffers activity updates, flushed to DB every 30 min by the monitor job
+ *
+ * Passive endpoints (/auth/validate, /auth/stream) do not update activity.
  */
 export const isAuthenticated = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {
@@ -50,23 +53,40 @@ export const isAuthenticated = asyncHandler(
       throw new UnauthorizedError('Token de acceso inválido');
     }
 
-    // 2. Verify session in database
-    const session = await sessionRepository.getById(decoded.session_id);
+    // 2. Check session cache (cache miss → DB read)
+    let sessionEntry = sessionCache.get(decoded.session_id);
 
-    if (!session || !session.is_active) {
-      throw new UnauthorizedError('Sesión inválida o expirada');
+    if (!sessionEntry) {
+      const session = await sessionRepository.getById(decoded.session_id);
+      if (!session || !session.is_active) {
+        throw new UnauthorizedError('Sesión inválida o expirada');
+      }
+      sessionEntry = {
+        user_id: session.user_id,
+        organization_id: session.organization_id,
+        expires_at: session.expires_at,
+        created_at: session.created_at,
+      };
+      sessionCache.set(decoded.session_id, sessionEntry);
     }
 
-    // 3. Check if session expired
-    if (new Date() > session.expires_at) {
-      await sessionRepository.revoke(session.session_id, 'expired');
+    // 3. Check expiry — activity cache may have a newer expires_at than the DB-sourced cache
+    const activityEntry = activityCache.get(decoded.session_id);
+    const effectiveExpiry = activityEntry ? activityEntry.expires_at : sessionEntry.expires_at;
+
+    if (new Date() > effectiveExpiry) {
+      await sessionRepository.revoke(decoded.session_id, 'expired');
+      sessionCache.delete(decoded.session_id);
+      activityCache.delete(decoded.session_id);
       throw new UnauthorizedError('Sesión expirada');
     }
 
-    // 4. Update session activity (sliding window)
-    // This extends the session expiration by INACTIVITY_TIMEOUT (4 hours)
-    // respecting the ABSOLUTE_TIMEOUT (30 days) limit
-    await sessionRepository.updateActivity(session.session_id, session.created_at);
+    // 4. Update activity for real requests (not passive endpoints)
+    const isPassive = PASSIVE_PATHS.some((p) => req.path.endsWith(p));
+    if (!isPassive) {
+      const newExpiry = activityCache.mark(decoded.session_id, sessionEntry.created_at);
+      sessionCache.updateExpiry(decoded.session_id, newExpiry);
+    }
 
     // 5. Get fresh user data from database
     const userData = await authRepository.getUserById(decoded.user_id);
@@ -74,10 +94,10 @@ export const isAuthenticated = asyncHandler(
     // 6. Attach user to request
     req.user = {
       user: parseUser(userData),
-      session_id: session.session_id,
-      organization_id: session.organization_id,
+      session_id: decoded.session_id,
+      organization_id: sessionEntry.organization_id,
     };
-    req.organization_id = session.organization_id;
+    req.organization_id = sessionEntry.organization_id;
 
     next();
   }
@@ -85,7 +105,6 @@ export const isAuthenticated = asyncHandler(
 
 /**
  * Helper function to get session info from request
- * Useful for controllers that need session details
  */
 export const getSessionInfo = (req: Request) => {
   if (!req.user) {

--- a/api/src/auth/controller/auth.controller.ts
+++ b/api/src/auth/controller/auth.controller.ts
@@ -8,6 +8,9 @@ import { SessionRepository } from 'api/src/session/repository/session.repository
 import { AuditRepository } from 'api/src/session/repository/audit.repository';
 import { signAccessToken, signRefreshToken, verifyRefreshToken } from 'api/helper/JWT';
 import { SESSION_CONFIG } from 'api/src/config/session.config';
+import { sessionCache } from 'api/src/session/cache/session.cache';
+import { activityCache } from 'api/src/session/cache/session-activity.cache';
+import { sseManager } from 'api/src/session/sse/session-sse.manager';
 
 export interface ILoginResponse {
   user: IUserEntityFront;
@@ -322,7 +325,8 @@ export class AuthController {
   };
 
   /**
-   * Logout (revoke session) (NEW - Phase 2)
+   * Logout (revoke session)
+   * Cleans in-memory caches and pushes SSE expiry event immediately.
    */
   logoutSession = async (
     sessionId: string,
@@ -331,6 +335,15 @@ export class AuthController {
   ): Promise<boolean> => {
     if (logoutAll) {
       await this.sessionRepository.revokeAllUserSessions(userId, 'user_logout_all');
+
+      // Clean all sessions for this user from both caches and SSE
+      const userSessionIds = sessionCache.getSessionIdsByUserId(userId);
+      for (const id of userSessionIds) {
+        sessionCache.delete(id);
+        activityCache.delete(id);
+        sseManager.expire(id);
+      }
+
       await this.auditRepository.log({
         user_id: userId,
         event_type: 'logout_all',
@@ -338,6 +351,11 @@ export class AuthController {
       });
     } else {
       await this.sessionRepository.revoke(sessionId, 'user_logout');
+
+      sessionCache.delete(sessionId);
+      activityCache.delete(sessionId);
+      sseManager.expire(sessionId);
+
       await this.auditRepository.log({
         user_id: userId,
         session_id: sessionId,

--- a/api/src/auth/route/auth.route.ts
+++ b/api/src/auth/route/auth.route.ts
@@ -6,6 +6,7 @@ import { asyncHandler } from '../../middlewares/error.middleware';
 import { UnauthorizedError } from '@helper/errors';
 import { loginSchema } from '@helper/schemas/auth.schema';
 import { SESSION_CONFIG } from 'api/src/config/session.config';
+import { sseManager } from 'api/src/session/sse/session-sse.manager';
 
 // Cookie configuration based on SESSION_CONFIG
 const COOKIE_OPTIONS = {
@@ -36,8 +37,9 @@ export class AuthRouter {
 
   private setupPrivateRoutes() {
     this.privateRouter.post('/logout', this.logoutHandler);
-    this.privateRouter.post('/logout-all', this.logoutAllHandler); // NEW - Phase 2
+    this.privateRouter.post('/logout-all', this.logoutAllHandler);
     this.privateRouter.get('/validate', this.validateHandler);
+    this.privateRouter.get('/stream', this.sessionStreamHandler);
   }
 
   /**
@@ -75,10 +77,13 @@ export class AuthRouter {
       maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
     });
 
-    // Respuesta exitosa
-    const response: APIResponse<IUserEntityFront> = {
+    // Incluye organization_id para que el frontend no necesite llamar a /validate post-login
+    const response: APIResponse<IUserEntityFront & { organization_id: string }> = {
       data: {
-        user: loginResponse.user,
+        user: {
+          ...loginResponse.user,
+          organization_id: loginResponse.organization_id,
+        },
       },
     };
 
@@ -165,7 +170,7 @@ export class AuthRouter {
 
   /**
    * GET /api/private/auth/validate
-   * Validate current session
+   * Passive session check — does not extend the session sliding window.
    */
   private validateHandler = asyncHandler(async (req: Request, res: Response) => {
     const { user } = req.user!;
@@ -184,5 +189,24 @@ export class AuthRouter {
     };
 
     res.status(200).json(response);
+  });
+
+  /**
+   * GET /api/private/auth/stream
+   * SSE stream — pushes session_expired event when session is revoked or expires.
+   * Replaces the periodic polling interval on the frontend.
+   * Passive: does not extend the session sliding window.
+   */
+  private sessionStreamHandler = asyncHandler(async (req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const sessionId = req.user!.session_id;
+    sseManager.add(sessionId, res);
+    res.write('data: {"type":"connected"}\n\n');
+
+    req.on('close', () => sseManager.remove(sessionId));
   });
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import { isAuthenticated } from '../middlewares/auth.middleware';
 import { errorHandler } from './middlewares/error.middleware';
 import { publicRouter, router } from './router';
 import { startSessionCleanupJob } from './utils/session-cleanup.job';
+import { startSessionMonitorJob, flushActivityCache } from './session/job/session-monitor.job';
 import { getCronService } from './cron/service/cron.service';
 import { initializeActiveDaysCache } from './archive/helper/archive-helper';
 import {
@@ -152,6 +153,9 @@ if (process.env.NODE_ENV !== 'test') {
     // Start session cleanup job (runs every hour)
     startSessionCleanupJob();
 
+    // Start session monitor job (flushes activity cache + checks revocations every 30 min)
+    startSessionMonitorJob();
+
     // Initialize active days cache (for query routing)
     await initializeActiveDaysCache();
 
@@ -161,6 +165,12 @@ if (process.env.NODE_ENV !== 'test') {
     console.log('[Archive] Cron job initialized - Daily archiving of old bets/tickets');
   });
 }
+
+// Flush activity cache on graceful shutdown so in-flight activity isn't lost
+process.on('SIGTERM', () => {
+  console.log('[Server] SIGTERM received, flushing activity cache...');
+  flushActivityCache().finally(() => process.exit(0));
+});
 
 // Exportar app para tests
 export default app;

--- a/api/src/session/cache/session-activity.cache.ts
+++ b/api/src/session/cache/session-activity.cache.ts
@@ -1,0 +1,50 @@
+import { SESSION_CONFIG } from 'api/src/config/session.config';
+
+export interface ActivityCacheEntry {
+  last_activity_at: Date;
+  expires_at: Date;
+}
+
+class SessionActivityCache {
+  private map = new Map<string, ActivityCacheEntry>();
+
+  /**
+   * Marks activity for a session. Returns the new expires_at.
+   */
+  mark(sessionId: string, createdAt: Date): Date {
+    const now = new Date();
+    const newExpiry = new Date(now.getTime() + SESSION_CONFIG.INACTIVITY_TIMEOUT);
+    const absoluteEnd = new Date(createdAt.getTime() + SESSION_CONFIG.ABSOLUTE_TIMEOUT);
+    const expires_at = newExpiry < absoluteEnd ? newExpiry : absoluteEnd;
+
+    this.map.set(sessionId, { last_activity_at: now, expires_at });
+    return expires_at;
+  }
+
+  get(sessionId: string): ActivityCacheEntry | undefined {
+    return this.map.get(sessionId);
+  }
+
+  delete(sessionId: string): void {
+    this.map.delete(sessionId);
+  }
+
+  /**
+   * Returns a copy of the map for flushing to DB, then clears the original.
+   */
+  snapshotAndClear(): Map<string, ActivityCacheEntry> {
+    const snapshot = new Map(this.map);
+    this.map.clear();
+    return snapshot;
+  }
+
+  getAllIds(): string[] {
+    return [...this.map.keys()];
+  }
+
+  size(): number {
+    return this.map.size;
+  }
+}
+
+export const activityCache = new SessionActivityCache();

--- a/api/src/session/cache/session.cache.ts
+++ b/api/src/session/cache/session.cache.ts
@@ -1,0 +1,42 @@
+interface SessionCacheEntry {
+  user_id: string;
+  organization_id: string;
+  expires_at: Date;
+  created_at: Date;
+}
+
+class SessionCache {
+  private map = new Map<string, SessionCacheEntry>();
+
+  get(sessionId: string): SessionCacheEntry | undefined {
+    return this.map.get(sessionId);
+  }
+
+  set(sessionId: string, entry: SessionCacheEntry): void {
+    this.map.set(sessionId, entry);
+  }
+
+  updateExpiry(sessionId: string, expiresAt: Date): void {
+    const entry = this.map.get(sessionId);
+    if (entry) entry.expires_at = expiresAt;
+  }
+
+  delete(sessionId: string): void {
+    this.map.delete(sessionId);
+  }
+
+  getSessionIdsByUserId(userId: string): string[] {
+    const ids: string[] = [];
+    for (const [sessionId, entry] of this.map) {
+      if (entry.user_id === userId) ids.push(sessionId);
+    }
+    return ids;
+  }
+
+  getAllIds(): string[] {
+    return [...this.map.keys()];
+  }
+}
+
+export const sessionCache = new SessionCache();
+export type { SessionCacheEntry };

--- a/api/src/session/job/session-monitor.job.ts
+++ b/api/src/session/job/session-monitor.job.ts
@@ -1,0 +1,73 @@
+import { sessionCache } from '../cache/session.cache';
+import { activityCache } from '../cache/session-activity.cache';
+import { sseManager } from '../sse/session-sse.manager';
+import { SessionRepository } from '../repository/session.repository';
+
+const sessionRepository = new SessionRepository();
+const JOB_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+export async function flushActivityCache(): Promise<void> {
+  const snapshot = activityCache.snapshotAndClear();
+  if (snapshot.size === 0) return;
+
+  try {
+    await sessionRepository.batchUpdateActivity(snapshot);
+    console.log(`[SessionMonitor] Flushed ${snapshot.size} activity entries to DB`);
+  } catch (err) {
+    console.error('[SessionMonitor] Failed to flush activity cache:', err);
+    // Data is lost but server keeps running — next flush will capture new activity
+  }
+}
+
+async function sessionMonitorJob(): Promise<void> {
+  try {
+    // 1. Flush activity cache first so DB is up-to-date before we re-read
+    await flushActivityCache();
+
+    // 2. Collect all tracked session IDs (cache + SSE connections)
+    const allIds = [...new Set([...sessionCache.getAllIds(), ...sseManager.getAllSessionIds()])];
+    if (allIds.length === 0) return;
+
+    // 3. Batch fetch from DB
+    const sessions = await sessionRepository.getBatchByIds(allIds);
+    const sessionMap = new Map(sessions.map((s) => [s.session_id, s]));
+
+    // 4. Process each session
+    const now = new Date();
+    let expired = 0;
+
+    for (const id of allIds) {
+      const session = sessionMap.get(id);
+      const isValid = session && session.is_active && now < session.expires_at;
+
+      if (!isValid) {
+        sseManager.expire(id);
+        sessionCache.delete(id);
+        activityCache.delete(id);
+        expired++;
+      } else {
+        // Refresh session cache with latest DB data
+        sessionCache.set(id, {
+          user_id: session.user_id,
+          organization_id: session.organization_id,
+          expires_at: session.expires_at,
+          created_at: session.created_at,
+        });
+      }
+    }
+
+    // 5. Ping SSE connections to detect dead ones
+    sseManager.pingAll();
+
+    console.log(
+      `[SessionMonitor] Job done. Tracked: ${allIds.length}, expired: ${expired}, SSE: ${sseManager.size()}`
+    );
+  } catch (err) {
+    console.error('[SessionMonitor] Job failed:', err);
+  }
+}
+
+export function startSessionMonitorJob(): void {
+  setInterval(() => void sessionMonitorJob(), JOB_INTERVAL_MS);
+  console.log('[SessionMonitor] Background job started (interval: 30 min)');
+}

--- a/api/src/session/repository/session.repository.ts
+++ b/api/src/session/repository/session.repository.ts
@@ -203,6 +203,56 @@ export class SessionRepository {
   }
 
   /**
+   * Get multiple sessions by IDs in a single query
+   */
+  async getBatchByIds(sessionIds: string[]): Promise<ISession[]> {
+    if (sessionIds.length === 0) return [];
+
+    const { data, error } = await supabase
+      .from('sessions')
+      .select('*')
+      .in('session_id', sessionIds);
+
+    if (error) {
+      console.error('[SessionRepository] Failed to batch get sessions:', error);
+      throw new InternalServerError('Failed to batch get sessions');
+    }
+
+    return (data || []).map(this.mapToSession);
+  }
+
+  /**
+   * Batch update session activity from in-memory cache flush.
+   * Uses a single Postgres function call regardless of the number of sessions.
+   */
+  async batchUpdateActivity(
+    entries: Map<string, { last_activity_at: Date; expires_at: Date }>
+  ): Promise<void> {
+    if (entries.size === 0) return;
+
+    const sessionIds: string[] = [];
+    const activityTimes: string[] = [];
+    const expiryTimes: string[] = [];
+
+    for (const [sessionId, entry] of entries) {
+      sessionIds.push(sessionId);
+      activityTimes.push(entry.last_activity_at.toISOString());
+      expiryTimes.push(entry.expires_at.toISOString());
+    }
+
+    const { error } = await supabase.rpc('batch_update_session_activity', {
+      p_session_ids: sessionIds,
+      p_activity_times: activityTimes,
+      p_expiry_times: expiryTimes,
+    });
+
+    if (error) {
+      console.error('[SessionRepository] Failed to batch update activity:', error);
+      throw new InternalServerError('Failed to batch update session activity');
+    }
+  }
+
+  /**
    * Cleanup expired sessions (called periodically)
    */
   async cleanupExpiredSessions(): Promise<number> {

--- a/api/src/session/sse/session-sse.manager.ts
+++ b/api/src/session/sse/session-sse.manager.ts
@@ -1,0 +1,49 @@
+import { Response } from 'express';
+
+class SessionSSEManager {
+  private connections = new Map<string, Response>();
+
+  add(sessionId: string, res: Response): void {
+    this.connections.set(sessionId, res);
+  }
+
+  remove(sessionId: string): void {
+    this.connections.delete(sessionId);
+  }
+
+  expire(sessionId: string): void {
+    const res = this.connections.get(sessionId);
+    if (!res) return;
+    try {
+      res.write('data: {"type":"session_expired"}\n\n');
+      res.end();
+    } catch {
+      // Connection already closed
+    }
+    this.connections.delete(sessionId);
+  }
+
+  /**
+   * Sends a ping to all connections to detect dead ones.
+   * Removes dead connections from the map.
+   */
+  pingAll(): void {
+    for (const [sessionId, res] of this.connections) {
+      try {
+        res.write('data: {"type":"ping"}\n\n');
+      } catch {
+        this.connections.delete(sessionId);
+      }
+    }
+  }
+
+  getAllSessionIds(): string[] {
+    return [...this.connections.keys()];
+  }
+
+  size(): number {
+    return this.connections.size;
+  }
+}
+
+export const sseManager = new SessionSSEManager();

--- a/api/supabase/migrations/20260407120000_batch_update_session_activity.sql
+++ b/api/supabase/migrations/20260407120000_batch_update_session_activity.sql
@@ -1,0 +1,26 @@
+-- Migration: Add batch_update_session_activity function
+-- Date: 2026-04-07
+-- Description: Efficient single-query batch update for session activity flush from in-memory cache
+
+CREATE OR REPLACE FUNCTION batch_update_session_activity(
+  p_session_ids UUID[],
+  p_activity_times TIMESTAMPTZ[],
+  p_expiry_times TIMESTAMPTZ[]
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE sessions s
+  SET
+    last_activity_at = data.last_activity_at,
+    expires_at = data.expires_at
+  FROM UNNEST(p_session_ids, p_activity_times, p_expiry_times)
+    AS data(session_id, last_activity_at, expires_at)
+  WHERE s.session_id = data.session_id
+    AND s.is_active = TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION batch_update_session_activity IS
+  'Batch updates last_activity_at and expires_at for multiple sessions in a single query. Used by the session monitor job to flush the in-memory activity cache to the database.';

--- a/helper/config/session.config.ts
+++ b/helper/config/session.config.ts
@@ -17,10 +17,10 @@
 export const SESSION_DURATION_MS = 4 * 60 * 60 * 1000; // 4 horas
 
 /**
- * Intervalo de validación periódica con el servidor (4 minutos)
+ * Intervalo de validación periódica con el servidor (5 minutos)
  * Se verifica que la sesión siga siendo válida cada este tiempo
  */
-export const VALIDATE_INTERVAL_MS = 4 * 60 * 1000; // 4 minutos
+export const VALIDATE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutos
 
 /**
  * Tiempo mínimo entre validaciones al volver a la pestaña (10 minutos)

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed - 2026-04-07
 
+#### Auth — SSE reemplaza polling periódico de sesión
+
+- **`providers/AuthProvider.tsx`**: Elimina el `setInterval` de validate cada 5 minutos. Reemplazado por una conexión `EventSource` a `/api/private/auth/stream`. El backend pushea `session_expired` cuando la sesión expira o es revocada. `EventSource` reconecta automáticamente en caso de error de red.
+- **`providers/AuthProvider.tsx`**: `login()` ya no llama a `validate()` post-login. Usa directamente la respuesta del endpoint de login que ahora incluye `organization_id`.
+- **`routes/routes.ts`**: Agrega `auth.stream` → `/api/private/auth/stream`.
+- **`helper/config/session.config.ts`**: Elimina el import de `VALIDATE_INTERVAL_MS` (ya no se usa en AuthProvider).
+
+### Changed - 2026-04-07
+
 #### Performance — optimizaciones de performance móvil (LCP/INP)
 
 **Objetivo:** reducir LCP móvil de 5.28s a ~2.0–2.5s e INP de 424ms a ~150–200ms

--- a/web/routes/routes.ts
+++ b/web/routes/routes.ts
@@ -9,6 +9,7 @@ export const BACKEND_ROUTES = {
     logout: `${PRIVATE}/auth/logout`,
     logoutAll: `${PRIVATE}/auth/logout-all`,
     validate: `${PRIVATE}/auth/validate`,
+    stream: `${PRIVATE}/auth/stream`,
   },
   user: {
     base: `${PRIVATE}/user`,

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -3,11 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { IUserEntityFront, USER_TYPE } from '@helper/types/user.type';
 import { AuthContext, AuthContextValue, LoginPayload } from '@/contexts/AuthContext';
 import { BACKEND_ROUTES } from '../../routes/routes';
-import {
-  VALIDATE_INTERVAL_MS,
-  VALIDATE_ON_VISIBILITY,
-  VISIBILITY_MIN_GAP_MS,
-} from '@helper/config/session.config';
+import { VALIDATE_ON_VISIBILITY, VISIBILITY_MIN_GAP_MS } from '@helper/config/session.config';
 import { apiClient, ApiError } from '@/lib/apiClient';
 import { AUTH_EXPIRED_EVENT } from '@/lib/authEvents';
 
@@ -30,7 +26,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const [optimisticAuth] = useState(() => sessionStorage.getItem('auth_hint') === '1');
   const [loading, setLoading] = useState(true);
 
-  const validateIntervalRef = useRef<number | null>(null);
   const refreshIntervalRef = useRef<number | null>(null);
   const lastValidateRef = useRef<number>(0);
 
@@ -75,25 +70,18 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     async (payload: LoginPayload) => {
       setLoading(true);
       try {
-        const user = await apiClient.post<IUserEntityFront>(
-          BACKEND_ROUTES.auth.login,
-          payload
-        );
-        if (!user) throw new Error('Respuesta inválida del servidor');
-
-        // validate establece la sesión con todos los datos (incluyendo organization_id)
-        await validate();
+        // Login now returns organization_id directly — no need for a validate() round-trip
+        const userData = await apiClient.post<UserWithOrg>(BACKEND_ROUTES.auth.login, payload);
+        if (!userData) throw new Error('Respuesta inválida del servidor');
+        setSession(userData);
       } catch (err) {
-        // Re-lanzar el error con el mensaje del servidor para que el componente lo capture
-        if (err instanceof ApiError) {
-          throw new Error(err.message);
-        }
+        if (err instanceof ApiError) throw new Error(err.message);
         throw err;
       } finally {
         setLoading(false);
       }
     },
-    [setSession, validate]
+    [setSession]
   );
 
   const logout = useCallback(
@@ -145,21 +133,28 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Validación periódica (cada 4 minutos)
-  // Backend maneja expiración de sesión con sliding window
+  // SSE — recibe session_expired del backend en lugar de hacer polling periódico
   useEffect(() => {
-    if (validateIntervalRef.current) window.clearInterval(validateIntervalRef.current);
+    if (!isAuth) return;
 
-    if (isAuth) {
-      validateIntervalRef.current = window.setInterval(() => {
-        void validate();
-      }, VALIDATE_INTERVAL_MS) as unknown as number;
-    }
+    const es = new EventSource(BACKEND_ROUTES.auth.stream, { withCredentials: true });
 
-    return () => {
-      if (validateIntervalRef.current) window.clearInterval(validateIntervalRef.current);
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as { type: string };
+        if (data.type === 'session_expired') {
+          queryClient.clear();
+          setSession(null);
+          es.close();
+        }
+      } catch {
+        // ignore malformed messages
+      }
     };
-  }, [isAuth, validate]);
+
+    // EventSource reconecta automáticamente en caso de error de red
+    return () => es.close();
+  }, [isAuth, setSession, queryClient]);
 
   // Auto-refresh de access token (cada 13-14 minutos)
   // Access token expira a los 15 minutos, refrescamos antes


### PR DESCRIPTION
- SessionCache eliminates DB reads on session validation (cache miss → DB read to populate)
- ActivityCache buffers sliding window updates; flushed to DB every 30 min via batch RPC
- SessionMonitorJob runs every 30 min: flushes activity, re-checks sessions, expires invalid ones
- SSEManager pushes session_expired to frontend immediately on logout/revocation
- SIGTERM handler flushes ActivityCache before shutdown
- Login response now includes organization_id, removing post-login validate() round-trip
- /validate and /stream marked as passive — do not extend session sliding window
- Frontend replaces 5-min polling interval with EventSource (SSE)

Result: 3 DB ops/request → 1 DB op/request + 2 batch queries per 30 min for all sessions