### PR TITLE
fix(archive): batch insert+delete to avoid statement timeout on 1M+ rows

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed - 2026-04-08
+
+#### Archive — batched processing to fix statement timeout on 1M+ rows
+
+- **`archive/service/archive.service.ts`**: Rewrote `archiveOldBetsManual` and `archiveOldTicketsManual` to process in batches of 5000 rows instead of a single massive SELECT/INSERT/DELETE. Each iteration fetches the next batch from the top of the table (no offset) since rows are deleted as we go. Uses `upsert` with `ignoreDuplicates` to handle safe re-runs after a partial failure.
+  - Why: Production cron job failed with `canceling statement due to statement timeout` trying to delete ~1M bets in one operation.
+- **`supabase/migrations/20260408070911_fix_archive_batch_processing.sql`** (nuevo): Replaces `archive_old_bets` and `archive_old_tickets` stored procedures with batched PL/pgSQL loop using `WITH to_delete AS (...LIMIT 5000) ... DELETE ... WHERE id IN (...)`. `ON CONFLICT DO NOTHING` makes it safe to re-run after partial failure.
+
 ### Added - 2026-04-07
 
 #### Session — cache en memoria + SSE para eliminar DB ops por request

--- a/api/src/archive/service/archive.service.ts
+++ b/api/src/archive/service/archive.service.ts
@@ -130,7 +130,7 @@ export class ArchiveService {
 
   /**
    * Manual implementation of archiving bets (fallback)
-   * This is database-agnostic and can be used if stored procedures fail
+   * Processes in batches to avoid statement timeouts on large tables.
    */
   private async archiveOldBetsManual(daysToKeep: number): Promise<IArchiveResult> {
     const cutoffDate = await this.activityDaysRepo.getCutoffDate(daysToKeep);
@@ -146,69 +146,71 @@ export class ArchiveService {
       };
     }
 
-    // cutoffDate is already a string after the null check
-    const cutoffDateStr = cutoffDate;
+    const BATCH_SIZE = 5000;
+    const archivedAt = new Date().toISOString();
+    let totalCount = 0;
 
-    // Get old bets (INCLUDING deleted ones)
-    const { data: oldBets, error: selectError } = await supabase
-      .from('bets')
-      .select('*')
-      .lt('date', cutoffDateStr);
-    // Note: Gets ALL bets (deleted_at IS NULL AND deleted_at IS NOT NULL)
+    // Process in batches: always fetch from the top since we delete as we go
+    while (true) {
+      const { data: batch, error: selectError } = await supabase
+        .from('bets')
+        .select('*')
+        .lt('date', cutoffDate)
+        .limit(BATCH_SIZE);
 
-    if (selectError) {
-      const errorMsg =
-        typeof selectError.message === 'string' ? selectError.message : JSON.stringify(selectError);
-      throw new Error(`Failed to select old bets: ${errorMsg}`);
-    }
+      if (selectError) {
+        const errorMsg =
+          typeof selectError.message === 'string'
+            ? selectError.message
+            : JSON.stringify(selectError);
+        throw new Error(`Failed to select old bets: ${errorMsg}`);
+      }
 
-    if (!oldBets || oldBets.length === 0) {
-      return {
-        success: true,
-        message: 'No bets to archive',
-        cutoff_date: cutoffDateStr,
-        archived_count: 0,
-        deleted_count: 0,
-        days_kept: daysToKeep,
-      };
-    }
+      if (!batch || batch.length === 0) break;
 
-    // Insert into archive
-    const betsToArchive = oldBets.map((bet) => ({
-      ...bet,
-      archived_at: new Date().toISOString(),
-    }));
+      const ids = batch.map((b) => b.bet_id);
 
-    const { error: insertError } = await supabase.from('bets_archive').insert(betsToArchive);
+      const { error: insertError } = await supabase.from('bets_archive').upsert(
+        batch.map((bet) => ({ ...bet, archived_at: archivedAt })),
+        { onConflict: 'bet_id', ignoreDuplicates: true }
+      );
 
-    if (insertError) {
-      const errorMsg =
-        typeof insertError.message === 'string' ? insertError.message : JSON.stringify(insertError);
-      throw new Error(`Failed to insert bets into archive: ${errorMsg}`);
-    }
+      if (insertError) {
+        const errorMsg =
+          typeof insertError.message === 'string'
+            ? insertError.message
+            : JSON.stringify(insertError);
+        throw new Error(`Failed to insert bets into archive: ${errorMsg}`);
+      }
 
-    // Delete from main table (INCLUDING deleted ones)
-    const { error: deleteError } = await supabase.from('bets').delete().lt('date', cutoffDateStr);
-    // Note: Deletes ALL archived bets (deleted_at IS NULL AND deleted_at IS NOT NULL)
+      const { error: deleteError } = await supabase.from('bets').delete().in('bet_id', ids);
 
-    if (deleteError) {
-      const errorMsg =
-        typeof deleteError.message === 'string' ? deleteError.message : JSON.stringify(deleteError);
-      throw new Error(`Failed to delete archived bets: ${errorMsg}`);
+      if (deleteError) {
+        const errorMsg =
+          typeof deleteError.message === 'string'
+            ? deleteError.message
+            : JSON.stringify(deleteError);
+        throw new Error(`Failed to delete archived bets: ${errorMsg}`);
+      }
+
+      totalCount += batch.length;
+
+      if (batch.length < BATCH_SIZE) break;
     }
 
     return {
       success: true,
-      message: 'Bets archived successfully',
-      cutoff_date: cutoffDateStr,
-      archived_count: oldBets.length,
-      deleted_count: oldBets.length,
+      message: totalCount === 0 ? 'No bets to archive' : 'Bets archived successfully',
+      cutoff_date: cutoffDate,
+      archived_count: totalCount,
+      deleted_count: totalCount,
       days_kept: daysToKeep,
     };
   }
 
   /**
    * Manual implementation of archiving tickets (fallback)
+   * Processes in batches to avoid statement timeouts on large tables.
    */
   private async archiveOldTicketsManual(daysToKeep: number): Promise<IArchiveResult> {
     const cutoffDate = await this.activityDaysRepo.getCutoffDate(daysToKeep);
@@ -224,66 +226,63 @@ export class ArchiveService {
       };
     }
 
-    // cutoffDate is already a string after the null check
-    const cutoffDateStr = cutoffDate;
+    const BATCH_SIZE = 5000;
+    const archivedAt = new Date().toISOString();
+    let totalCount = 0;
 
-    // Get old tickets (INCLUDING deleted ones)
-    const { data: oldTickets, error: selectError } = await supabase
-      .from('tickets')
-      .select('*')
-      .lt('date', cutoffDateStr);
-    // Note: Gets ALL tickets (deleted_at IS NULL AND deleted_at IS NOT NULL)
+    while (true) {
+      const { data: batch, error: selectError } = await supabase
+        .from('tickets')
+        .select('*')
+        .lt('date', cutoffDate)
+        .limit(BATCH_SIZE);
 
-    if (selectError) {
-      const errorMsg =
-        typeof selectError.message === 'string' ? selectError.message : JSON.stringify(selectError);
-      throw new Error(`Failed to select old tickets: ${errorMsg}`);
-    }
+      if (selectError) {
+        const errorMsg =
+          typeof selectError.message === 'string'
+            ? selectError.message
+            : JSON.stringify(selectError);
+        throw new Error(`Failed to select old tickets: ${errorMsg}`);
+      }
 
-    if (!oldTickets || oldTickets.length === 0) {
-      return {
-        success: true,
-        message: 'No tickets to archive',
-        cutoff_date: cutoffDateStr,
-        archived_count: 0,
-        deleted_count: 0,
-        days_kept: daysToKeep,
-      };
-    }
+      if (!batch || batch.length === 0) break;
 
-    // Insert into archive
-    const ticketsToArchive = oldTickets.map((ticket) => ({
-      ...ticket,
-      archived_at: new Date().toISOString(),
-    }));
+      const ids = batch.map((t) => t.ticket_id);
 
-    const { error: insertError } = await supabase.from('tickets_archive').insert(ticketsToArchive);
+      const { error: insertError } = await supabase.from('tickets_archive').upsert(
+        batch.map((ticket) => ({ ...ticket, archived_at: archivedAt })),
+        { onConflict: 'ticket_id', ignoreDuplicates: true }
+      );
 
-    if (insertError) {
-      const errorMsg =
-        typeof insertError.message === 'string' ? insertError.message : JSON.stringify(insertError);
-      throw new Error(`Failed to insert tickets into archive: ${errorMsg}`);
-    }
+      if (insertError) {
+        const errorMsg =
+          typeof insertError.message === 'string'
+            ? insertError.message
+            : JSON.stringify(insertError);
+        throw new Error(`Failed to insert tickets into archive: ${errorMsg}`);
+      }
 
-    // Delete from main table (INCLUDING deleted ones)
-    const { error: deleteError } = await supabase
-      .from('tickets')
-      .delete()
-      .lt('date', cutoffDateStr);
-    // Note: Deletes ALL archived tickets (deleted_at IS NULL AND deleted_at IS NOT NULL)
+      const { error: deleteError } = await supabase.from('tickets').delete().in('ticket_id', ids);
 
-    if (deleteError) {
-      const errorMsg =
-        typeof deleteError.message === 'string' ? deleteError.message : JSON.stringify(deleteError);
-      throw new Error(`Failed to delete archived tickets: ${errorMsg}`);
+      if (deleteError) {
+        const errorMsg =
+          typeof deleteError.message === 'string'
+            ? deleteError.message
+            : JSON.stringify(deleteError);
+        throw new Error(`Failed to delete archived tickets: ${errorMsg}`);
+      }
+
+      totalCount += batch.length;
+
+      if (batch.length < BATCH_SIZE) break;
     }
 
     return {
       success: true,
-      message: 'Tickets archived successfully',
-      cutoff_date: cutoffDateStr,
-      archived_count: oldTickets.length,
-      deleted_count: oldTickets.length,
+      message: totalCount === 0 ? 'No tickets to archive' : 'Tickets archived successfully',
+      cutoff_date: cutoffDate,
+      archived_count: totalCount,
+      deleted_count: totalCount,
       days_kept: daysToKeep,
     };
   }

--- a/api/supabase/migrations/20260408070911_fix_archive_batch_processing.sql
+++ b/api/supabase/migrations/20260408070911_fix_archive_batch_processing.sql
@@ -1,0 +1,157 @@
+-- Fix archive stored procedures to use batched processing
+-- Previous implementation did single DELETE on 1M+ rows, causing statement timeout.
+-- New implementation loops in batches of 5000 rows.
+
+DROP FUNCTION IF EXISTS archive_old_bets(INTEGER);
+
+CREATE OR REPLACE FUNCTION archive_old_bets(p_days_to_keep INTEGER DEFAULT 2)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cutoff_date DATE;
+  v_total_count INTEGER := 0;
+  v_batch_size INTEGER := 5000;
+  v_batch_deleted INTEGER;
+BEGIN
+  SELECT ad.date INTO v_cutoff_date
+  FROM activity_days ad
+  WHERE ad.has_activity = true
+  ORDER BY ad.date DESC
+  OFFSET p_days_to_keep - 1
+  LIMIT 1;
+
+  IF v_cutoff_date IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'message', 'Not enough active days to archive',
+      'cutoff_date', NULL,
+      'archived_count', 0,
+      'deleted_count', 0,
+      'days_kept', p_days_to_keep
+    );
+  END IF;
+
+  LOOP
+    WITH to_delete AS (
+      SELECT bet_id FROM bets WHERE date < v_cutoff_date LIMIT v_batch_size
+    ),
+    archived AS (
+      INSERT INTO bets_archive
+      SELECT
+        b.bet_id, b.bet_type, b.ticket_id, b.user_id, b.number, b.amount, b.place,
+        b."with", b.position, b.date, b.winner, b.paid, b.lottery_id, b.schedule_id,
+        b.created_at, b.edited_at, b.deleted_at, NOW() AS archived_at
+      FROM bets b
+      WHERE b.bet_id IN (SELECT bet_id FROM to_delete)
+      ON CONFLICT (bet_id) DO NOTHING
+    )
+    DELETE FROM bets WHERE bet_id IN (SELECT bet_id FROM to_delete);
+
+    GET DIAGNOSTICS v_batch_deleted = ROW_COUNT;
+    v_total_count := v_total_count + v_batch_deleted;
+
+    EXIT WHEN v_batch_deleted = 0;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', 'Bets archived successfully',
+    'cutoff_date', v_cutoff_date,
+    'archived_count', v_total_count,
+    'deleted_count', v_total_count,
+    'days_kept', p_days_to_keep
+  );
+END;
+$$;
+
+DROP FUNCTION IF EXISTS archive_old_tickets(INTEGER);
+
+CREATE OR REPLACE FUNCTION archive_old_tickets(p_days_to_keep INTEGER DEFAULT 2)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cutoff_date DATE;
+  v_total_count INTEGER := 0;
+  v_batch_size INTEGER := 5000;
+  v_batch_deleted INTEGER;
+BEGIN
+  SELECT ad.date INTO v_cutoff_date
+  FROM activity_days ad
+  WHERE ad.has_activity = true
+  ORDER BY ad.date DESC
+  OFFSET p_days_to_keep - 1
+  LIMIT 1;
+
+  IF v_cutoff_date IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'message', 'Not enough active days to archive',
+      'cutoff_date', NULL,
+      'archived_count', 0,
+      'deleted_count', 0,
+      'days_kept', p_days_to_keep
+    );
+  END IF;
+
+  LOOP
+    WITH to_delete AS (
+      SELECT ticket_id FROM tickets WHERE date < v_cutoff_date LIMIT v_batch_size
+    ),
+    archived AS (
+      INSERT INTO tickets_archive
+      SELECT
+        t.ticket_id, t.user_id, t.user_name, t.ticket_number, t.date,
+        t.paid, t.winner, t.total, t.created_at, t.deleted_at, t.deleted_by,
+        NOW() AS archived_at
+      FROM tickets t
+      WHERE t.ticket_id IN (SELECT ticket_id FROM to_delete)
+      ON CONFLICT (ticket_id) DO NOTHING
+    )
+    DELETE FROM tickets WHERE ticket_id IN (SELECT ticket_id FROM to_delete);
+
+    GET DIAGNOSTICS v_batch_deleted = ROW_COUNT;
+    v_total_count := v_total_count + v_batch_deleted;
+
+    EXIT WHEN v_batch_deleted = 0;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', 'Tickets archived successfully',
+    'cutoff_date', v_cutoff_date,
+    'archived_count', v_total_count,
+    'deleted_count', v_total_count,
+    'days_kept', p_days_to_keep
+  );
+END;
+$$;
+
+DROP FUNCTION IF EXISTS archive_old_data(INTEGER);
+
+CREATE OR REPLACE FUNCTION archive_old_data(p_days_to_keep INTEGER DEFAULT 2)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_bets_result JSONB;
+  v_tickets_result JSONB;
+  v_start_time TIMESTAMP;
+  v_end_time TIMESTAMP;
+BEGIN
+  v_start_time := clock_timestamp();
+
+  SELECT archive_old_bets(p_days_to_keep) INTO v_bets_result;
+  SELECT archive_old_tickets(p_days_to_keep) INTO v_tickets_result;
+
+  v_end_time := clock_timestamp();
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'bets', v_bets_result,
+    'tickets', v_tickets_result,
+    'execution_time_ms', EXTRACT(MILLISECONDS FROM (v_end_time - v_start_time))
+  );
+END;
+$$;


### PR DESCRIPTION
Previous implementation issued a single DELETE on ~1M bets, hitting Supabase's statement timeout. Both the stored procedure and TypeScript fallback now process in chunks of 5000 rows. Uses ON CONFLICT/upsert so partial re-runs after a failure are safe.