### PR TITLE
feat(analytics): add device & client stats tracking with 6h cache flush

### DIFF
--- a/api/src/analytics/cache/client-stats.cache.ts
+++ b/api/src/analytics/cache/client-stats.cache.ts
@@ -1,0 +1,39 @@
+import { ClientInfo } from '../helper/device-detector';
+
+const SEP = '|||';
+
+class ClientStatsCache {
+  private pending = new Map<string, number>();
+
+  increment(info: ClientInfo, by = 1): void {
+    const key = [
+      info.device_vendor,
+      info.device_model,
+      info.os_name,
+      info.os_version,
+      info.browser_name,
+      info.browser_major,
+    ].join(SEP);
+    this.pending.set(key, (this.pending.get(key) ?? 0) + by);
+  }
+
+  snapshotAndClear(): Array<{ info: ClientInfo; count: number }> {
+    const result: Array<{ info: ClientInfo; count: number }> = [];
+    for (const [key, count] of this.pending) {
+      const [device_vendor, device_model, os_name, os_version, browser_name, browser_major] =
+        key.split(SEP);
+      result.push({
+        info: { device_vendor, device_model, os_name, os_version, browser_name, browser_major },
+        count,
+      });
+    }
+    this.pending.clear();
+    return result;
+  }
+
+  size(): number {
+    return this.pending.size;
+  }
+}
+
+export const clientStatsCache = new ClientStatsCache();

--- a/api/src/analytics/cache/device-stats.cache.ts
+++ b/api/src/analytics/cache/device-stats.cache.ts
@@ -1,0 +1,19 @@
+class DeviceStatsCache {
+  private pending = new Map<string, number>();
+
+  increment(key: string, by = 1): void {
+    this.pending.set(key, (this.pending.get(key) ?? 0) + by);
+  }
+
+  snapshotAndClear(): Map<string, number> {
+    const snapshot = new Map(this.pending);
+    this.pending.clear();
+    return snapshot;
+  }
+
+  size(): number {
+    return this.pending.size;
+  }
+}
+
+export const deviceStatsCache = new DeviceStatsCache();

--- a/api/src/analytics/helper/device-detector.ts
+++ b/api/src/analytics/helper/device-detector.ts
@@ -1,0 +1,135 @@
+export type DeviceType = 'mobile' | 'tablet' | 'desktop' | 'bot' | 'unknown';
+
+export function detectDevice(userAgent?: string | null): DeviceType {
+  if (!userAgent) return 'unknown';
+  if (/bot|crawler|spider|slurp|facebookexternalhit/i.test(userAgent)) return 'bot';
+  if (/ipad|tablet|kindle/i.test(userAgent)) return 'tablet';
+  if (/mobile|android|iphone|ipod|blackberry|windows phone/i.test(userAgent)) return 'mobile';
+  return 'desktop';
+}
+
+export interface ClientInfo {
+  device_vendor: string;
+  device_model: string;
+  os_name: string;
+  os_version: string;
+  browser_name: string;
+  browser_major: string;
+}
+
+const UNKNOWN = 'unknown';
+
+const ANDROID_VENDORS: [RegExp, string][] = [
+  [/samsung|SM-|SCH-|SGH-|SHV-|SPH-/i, 'Samsung'],
+  [/xiaomi|redmi|poco/i, 'Xiaomi'],
+  [/huawei|honor/i, 'Huawei'],
+  [/motorola|moto\s/i, 'Motorola'],
+  [/LGE|LG-/i, 'LG'],
+  [/sony|xperia/i, 'Sony'],
+  [/oneplus/i, 'OnePlus'],
+  [/asus/i, 'ASUS'],
+  [/oppo/i, 'OPPO'],
+  [/vivo/i, 'Vivo'],
+  [/realme/i, 'Realme'],
+  [/nokia/i, 'Nokia'],
+  [/tcl/i, 'TCL'],
+];
+
+export function parseUA(userAgent?: string | null): ClientInfo {
+  const empty: ClientInfo = {
+    device_vendor: UNKNOWN,
+    device_model: UNKNOWN,
+    os_name: UNKNOWN,
+    os_version: UNKNOWN,
+    browser_name: UNKNOWN,
+    browser_major: UNKNOWN,
+  };
+
+  if (!userAgent) return empty;
+
+  const ua = userAgent;
+
+  // ── OS ──────────────────────────────────────────────────────────────────
+  let os_name = UNKNOWN;
+  let os_version = UNKNOWN;
+
+  const androidM = ua.match(/Android ([\d.]+)/);
+  if (androidM) {
+    os_name = 'Android';
+    os_version = androidM[1].split('.')[0]; // major only
+  } else if (/iPhone|iPad|iPod/.test(ua)) {
+    const iosM = ua.match(/OS ([\d_]+)/);
+    os_name = 'iOS';
+    if (iosM) os_version = iosM[1].split('_')[0];
+  } else if (/Windows NT/.test(ua)) {
+    os_name = 'Windows';
+    const winM = ua.match(/Windows NT ([\d.]+)/);
+    if (winM) {
+      const map: Record<string, string> = { '10.0': '10/11', '6.3': '8.1', '6.2': '8', '6.1': '7' };
+      os_version = map[winM[1]] ?? winM[1];
+    }
+  } else if (/Mac OS X/.test(ua)) {
+    os_name = 'macOS';
+    const macM = ua.match(/Mac OS X ([\d_.]+)/);
+    if (macM) os_version = macM[1].split(/[_.]/, 1)[0];
+  } else if (/Linux/.test(ua)) {
+    os_name = 'Linux';
+  }
+
+  // ── Device ──────────────────────────────────────────────────────────────
+  let device_vendor = UNKNOWN;
+  let device_model = UNKNOWN;
+
+  if (os_name === 'Android') {
+    // UA format: (Linux; Android X.X; Vendor Model Build/...)
+    const devM = ua.match(/Android [\d.]+;\s*([^)]+)\)/);
+    if (devM) {
+      const raw = devM[1].split(/\s+Build\//)[0].trim(); // strip "Build/..."
+      device_model = raw;
+      for (const [pattern, vendor] of ANDROID_VENDORS) {
+        if (pattern.test(raw) || pattern.test(ua)) {
+          device_vendor = vendor;
+          break;
+        }
+      }
+    }
+  } else if (os_name === 'iOS') {
+    device_vendor = 'Apple';
+    device_model = /iPad/.test(ua) ? 'iPad' : /iPod/.test(ua) ? 'iPod' : 'iPhone';
+  } else if (os_name === 'macOS') {
+    device_vendor = 'Apple';
+    device_model = 'Mac';
+  } else if (os_name === 'Windows') {
+    device_vendor = 'PC';
+    device_model = 'Windows PC';
+  } else if (os_name === 'Linux') {
+    device_vendor = 'PC';
+    device_model = 'Linux PC';
+  }
+
+  // ── Browser ─────────────────────────────────────────────────────────────
+  let browser_name = UNKNOWN;
+  let browser_major = UNKNOWN;
+
+  // Order matters: Edge & Opera both contain "Chrome/" in their UA
+  const browserPatterns: [RegExp, string, RegExp][] = [
+    [/Edg\//, 'Edge', /Edg\/([\d]+)/],
+    [/OPR\//, 'Opera', /OPR\/([\d]+)/],
+    [/SamsungBrowser\//, 'Samsung Browser', /SamsungBrowser\/([\d]+)/],
+    [/Chrome\//, 'Chrome', /Chrome\/([\d]+)/],
+    [/Firefox\//, 'Firefox', /Firefox\/([\d]+)/],
+    [/Version\/.*Safari/, 'Safari', /Version\/([\d]+)/],
+    [/Safari\//, 'Safari', /Safari\/([\d]+)/],
+  ];
+
+  for (const [detect, name, versionRe] of browserPatterns) {
+    if (detect.test(ua)) {
+      browser_name = name;
+      const m = ua.match(versionRe);
+      if (m) browser_major = m[1];
+      break;
+    }
+  }
+
+  return { device_vendor, device_model, os_name, os_version, browser_name, browser_major };
+}

--- a/api/src/analytics/helper/device-detector.ts
+++ b/api/src/analytics/helper/device-detector.ts
@@ -1,7 +1,7 @@
 export type DeviceType = 'mobile' | 'tablet' | 'desktop' | 'bot' | 'unknown';
 
 export function detectDevice(userAgent?: string | null): DeviceType {
-  if (!userAgent) return 'unknown';
+  if (!userAgent || userAgent.length > 500) return 'unknown';
   if (/bot|crawler|spider|slurp|facebookexternalhit/i.test(userAgent)) return 'bot';
   if (/ipad|tablet|kindle/i.test(userAgent)) return 'tablet';
   if (/mobile|android|iphone|ipod|blackberry|windows phone/i.test(userAgent)) return 'mobile';
@@ -53,6 +53,7 @@ export function parseUA(userAgent?: string | null): ClientInfo {
   };
 
   if (!userAgent) return empty;
+  if (userAgent.length > 500) return empty;
 
   const ua = userAgent;
 

--- a/api/src/analytics/helper/device-detector.ts
+++ b/api/src/analytics/helper/device-detector.ts
@@ -19,6 +19,13 @@ export interface ClientInfo {
 
 const UNKNOWN = 'unknown';
 
+// Strip non-printable ASCII and truncate to avoid storing arbitrary user-controlled strings
+const sanitize = (val: string, maxLen = 80): string =>
+  val
+    .replace(/[^\x20-\x7E]/g, '')
+    .trim()
+    .slice(0, maxLen) || UNKNOWN;
+
 const ANDROID_VENDORS: [RegExp, string][] = [
   [/samsung|SM-|SCH-|SGH-|SHV-|SPH-/i, 'Samsung'],
   [/xiaomi|redmi|poco/i, 'Xiaomi'],
@@ -85,7 +92,7 @@ export function parseUA(userAgent?: string | null): ClientInfo {
     const devM = ua.match(/Android [\d.]+;\s*([^)]+)\)/);
     if (devM) {
       const raw = devM[1].split(/\s+Build\//)[0].trim(); // strip "Build/..."
-      device_model = raw;
+      device_model = sanitize(raw);
       for (const [pattern, vendor] of ANDROID_VENDORS) {
         if (pattern.test(raw) || pattern.test(ua)) {
           device_vendor = vendor;

--- a/api/src/analytics/job/device-stats.job.ts
+++ b/api/src/analytics/job/device-stats.job.ts
@@ -1,0 +1,35 @@
+import { deviceStatsCache } from '../cache/device-stats.cache';
+import { clientStatsCache } from '../cache/client-stats.cache';
+import { DeviceStatsRepository } from '../repository/device-stats.repository';
+
+const repository = new DeviceStatsRepository();
+const JOB_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export async function flushDeviceStats(): Promise<void> {
+  const deviceSnapshot = deviceStatsCache.snapshotAndClear();
+  const clientSnapshot = clientStatsCache.snapshotAndClear();
+
+  if (deviceSnapshot.size === 0 && clientSnapshot.length === 0) return;
+
+  const results = await Promise.allSettled([
+    deviceSnapshot.size > 0 ? repository.batchUpsert(deviceSnapshot) : Promise.resolve(),
+    clientSnapshot.length > 0 ? repository.batchUpsertClient(clientSnapshot) : Promise.resolve(),
+  ]);
+
+  if (results[0].status === 'fulfilled' && deviceSnapshot.size > 0) {
+    console.log(`[DeviceStats] Flushed ${deviceSnapshot.size} stat entries to DB`);
+  } else if (results[0].status === 'rejected') {
+    console.error('[DeviceStats] Failed to flush device stats:', results[0].reason);
+  }
+
+  if (results[1].status === 'fulfilled' && clientSnapshot.length > 0) {
+    console.log(`[DeviceStats] Flushed ${clientSnapshot.length} client stat entries to DB`);
+  } else if (results[1].status === 'rejected') {
+    console.error('[DeviceStats] Failed to flush client stats:', results[1].reason);
+  }
+}
+
+export function startDeviceStatsJob(): void {
+  setInterval(() => void flushDeviceStats(), JOB_INTERVAL_MS);
+  console.log('[DeviceStats] Background job started (interval: 6h)');
+}

--- a/api/src/analytics/repository/device-stats.repository.ts
+++ b/api/src/analytics/repository/device-stats.repository.ts
@@ -1,0 +1,46 @@
+import { supabase } from '@database/db.connection';
+import { InternalServerError } from '@helper/errors';
+import { ClientInfo } from '../helper/device-detector';
+
+export class DeviceStatsRepository {
+  async batchUpsert(entries: Map<string, number>): Promise<void> {
+    if (entries.size === 0) return;
+
+    const keys: string[] = [];
+    const counts: number[] = [];
+
+    for (const [key, count] of entries) {
+      keys.push(key);
+      counts.push(count);
+    }
+
+    const { error } = await supabase.rpc('upsert_device_stats', {
+      p_keys: keys,
+      p_counts: counts,
+    });
+
+    if (error) {
+      console.error('[DeviceStatsRepository] Failed to upsert device stats:', error);
+      throw new InternalServerError('Failed to upsert device stats');
+    }
+  }
+
+  async batchUpsertClient(entries: Array<{ info: ClientInfo; count: number }>): Promise<void> {
+    if (entries.length === 0) return;
+
+    const { error } = await supabase.rpc('upsert_client_stats', {
+      p_vendors: entries.map((e) => e.info.device_vendor),
+      p_models: entries.map((e) => e.info.device_model),
+      p_os_names: entries.map((e) => e.info.os_name),
+      p_os_versions: entries.map((e) => e.info.os_version),
+      p_browsers: entries.map((e) => e.info.browser_name),
+      p_browser_majors: entries.map((e) => e.info.browser_major),
+      p_counts: entries.map((e) => e.count),
+    });
+
+    if (error) {
+      console.error('[DeviceStatsRepository] Failed to upsert client stats:', error);
+      throw new InternalServerError('Failed to upsert client stats');
+    }
+  }
+}

--- a/api/src/auth/controller/auth.controller.ts
+++ b/api/src/auth/controller/auth.controller.ts
@@ -11,6 +11,9 @@ import { SESSION_CONFIG } from 'api/src/config/session.config';
 import { sessionCache } from 'api/src/session/cache/session.cache';
 import { activityCache } from 'api/src/session/cache/session-activity.cache';
 import { sseManager } from 'api/src/session/sse/session-sse.manager';
+import { deviceStatsCache } from 'api/src/analytics/cache/device-stats.cache';
+import { clientStatsCache } from 'api/src/analytics/cache/client-stats.cache';
+import { detectDevice, parseUA } from 'api/src/analytics/helper/device-detector';
 
 export interface ILoginResponse {
   user: IUserEntityFront;
@@ -176,6 +179,10 @@ export class AuthController {
       finalRefreshTokenHash,
       session.refresh_token_version + 1
     );
+
+    // Track device type + detailed client info in analytics cache (fire-and-forget)
+    deviceStatsCache.increment(`device:${detectDevice(userAgent)}`);
+    clientStatsCache.increment(parseUA(userAgent));
 
     // 8, 9, 10. Run independent post-login updates in parallel
     await Promise.all([

--- a/api/src/auth/route/auth.route.ts
+++ b/api/src/auth/route/auth.route.ts
@@ -7,6 +7,7 @@ import { UnauthorizedError } from '@helper/errors';
 import { loginSchema } from '@helper/schemas/auth.schema';
 import { SESSION_CONFIG } from 'api/src/config/session.config';
 import { sseManager } from 'api/src/session/sse/session-sse.manager';
+import { deviceStatsCache } from 'api/src/analytics/cache/device-stats.cache';
 
 // Cookie configuration based on SESSION_CONFIG
 const COOKIE_OPTIONS = {
@@ -40,6 +41,7 @@ export class AuthRouter {
     this.privateRouter.post('/logout-all', this.logoutAllHandler);
     this.privateRouter.get('/validate', this.validateHandler);
     this.privateRouter.get('/stream', this.sessionStreamHandler);
+    this.privateRouter.patch('/connection', this.connectionHandler);
   }
 
   /**
@@ -188,6 +190,20 @@ export class AuthRouter {
       },
     };
 
+    res.status(200).json(response);
+  });
+
+  /**
+   * PATCH /api/private/auth/connection
+   * Called once by the frontend after login to report connection type.
+   * Increments the in-memory analytics cache (flushed to DB every 6h).
+   */
+  private connectionHandler = asyncHandler(async (req: Request, res: Response) => {
+    const { connection_type } = req.body;
+    if (connection_type && typeof connection_type === 'string') {
+      deviceStatsCache.increment(`conn:${connection_type}`);
+    }
+    const response: APIResponse<boolean> = { data: { ok: true } };
     res.status(200).json(response);
   });
 

--- a/api/src/auth/route/auth.route.ts
+++ b/api/src/auth/route/auth.route.ts
@@ -9,6 +9,8 @@ import { SESSION_CONFIG } from 'api/src/config/session.config';
 import { sseManager } from 'api/src/session/sse/session-sse.manager';
 import { deviceStatsCache } from 'api/src/analytics/cache/device-stats.cache';
 
+const ALLOWED_CONNECTION_TYPES = new Set(['4g', '3g', '2g', 'slow-2g', 'safari', 'unknown']);
+
 // Cookie configuration based on SESSION_CONFIG
 const COOKIE_OPTIONS = {
   httpOnly: true,
@@ -200,7 +202,7 @@ export class AuthRouter {
    */
   private connectionHandler = asyncHandler(async (req: Request, res: Response) => {
     const { connection_type } = req.body;
-    if (connection_type && typeof connection_type === 'string') {
+    if (typeof connection_type === 'string' && ALLOWED_CONNECTION_TYPES.has(connection_type)) {
       deviceStatsCache.increment(`conn:${connection_type}`);
     }
     const response: APIResponse<boolean> = { data: { ok: true } };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -8,6 +8,7 @@ import { errorHandler } from './middlewares/error.middleware';
 import { publicRouter, router } from './router';
 import { startSessionCleanupJob } from './utils/session-cleanup.job';
 import { startSessionMonitorJob, flushActivityCache } from './session/job/session-monitor.job';
+import { startDeviceStatsJob, flushDeviceStats } from './analytics/job/device-stats.job';
 import { getCronService } from './cron/service/cron.service';
 import { initializeActiveDaysCache } from './archive/helper/archive-helper';
 import {
@@ -156,6 +157,9 @@ if (process.env.NODE_ENV !== 'test') {
     // Start session monitor job (flushes activity cache + checks revocations every 30 min)
     startSessionMonitorJob();
 
+    // Start device stats job (flushes analytics cache to DB every 6h)
+    startDeviceStatsJob();
+
     // Initialize active days cache (for query routing)
     await initializeActiveDaysCache();
 
@@ -168,8 +172,8 @@ if (process.env.NODE_ENV !== 'test') {
 
 // Flush activity cache on graceful shutdown so in-flight activity isn't lost
 process.on('SIGTERM', () => {
-  console.log('[Server] SIGTERM received, flushing activity cache...');
-  flushActivityCache().finally(() => process.exit(0));
+  console.log('[Server] SIGTERM received, flushing caches...');
+  Promise.all([flushActivityCache(), flushDeviceStats()]).finally(() => process.exit(0));
 });
 
 // Exportar app para tests

--- a/api/supabase/migrations/20260409120000_create_analytics_device_stats.sql
+++ b/api/supabase/migrations/20260409120000_create_analytics_device_stats.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS analytics_device_stats (
+  stat_key    TEXT        PRIMARY KEY,
+  count       BIGINT      NOT NULL DEFAULT 0,
+  last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Atomic increment upsert — avoids race conditions on concurrent flushes
+CREATE OR REPLACE FUNCTION upsert_device_stats(
+  p_keys   TEXT[],
+  p_counts BIGINT[]
+) RETURNS VOID
+LANGUAGE plpgsql AS $$
+DECLARE
+  i INT;
+BEGIN
+  FOR i IN 1..array_length(p_keys, 1) LOOP
+    INSERT INTO analytics_device_stats (stat_key, count, last_updated)
+    VALUES (p_keys[i], p_counts[i], NOW())
+    ON CONFLICT (stat_key) DO UPDATE SET
+      count        = analytics_device_stats.count + EXCLUDED.count,
+      last_updated = NOW();
+  END LOOP;
+END;
+$$;

--- a/api/supabase/migrations/20260409130000_create_analytics_client_stats.sql
+++ b/api/supabase/migrations/20260409130000_create_analytics_client_stats.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS analytics_client_stats (
+  device_vendor  TEXT NOT NULL DEFAULT 'unknown',
+  device_model   TEXT NOT NULL DEFAULT 'unknown',
+  os_name        TEXT NOT NULL DEFAULT 'unknown',
+  os_version     TEXT NOT NULL DEFAULT 'unknown',
+  browser_name   TEXT NOT NULL DEFAULT 'unknown',
+  browser_major  TEXT NOT NULL DEFAULT 'unknown',
+  count          BIGINT NOT NULL DEFAULT 0,
+  last_updated   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (device_vendor, device_model, os_name, os_version, browser_name, browser_major)
+);
+
+-- Batch upsert with atomic increment using UNNEST (one statement, no loop)
+CREATE OR REPLACE FUNCTION upsert_client_stats(
+  p_vendors        TEXT[],
+  p_models         TEXT[],
+  p_os_names       TEXT[],
+  p_os_versions    TEXT[],
+  p_browsers       TEXT[],
+  p_browser_majors TEXT[],
+  p_counts         BIGINT[]
+) RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO analytics_client_stats
+    (device_vendor, device_model, os_name, os_version, browser_name, browser_major, count, last_updated)
+  SELECT
+    UNNEST(p_vendors),
+    UNNEST(p_models),
+    UNNEST(p_os_names),
+    UNNEST(p_os_versions),
+    UNNEST(p_browsers),
+    UNNEST(p_browser_majors),
+    UNNEST(p_counts),
+    NOW()
+  ON CONFLICT (device_vendor, device_model, os_name, os_version, browser_name, browser_major)
+  DO UPDATE SET
+    count        = analytics_client_stats.count + EXCLUDED.count,
+    last_updated = NOW();
+END;
+$$;

--- a/web/routes/routes.ts
+++ b/web/routes/routes.ts
@@ -10,6 +10,7 @@ export const BACKEND_ROUTES = {
     logoutAll: `${PRIVATE}/auth/logout-all`,
     validate: `${PRIVATE}/auth/validate`,
     stream: `${PRIVATE}/auth/stream`,
+    connection: `${PRIVATE}/auth/connection`,
   },
   user: {
     base: `${PRIVATE}/user`,

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -133,6 +133,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Report connection type once per authenticated session (analytics)
+  useEffect(() => {
+    if (!isAuth) return;
+    const conn = (navigator as any).connection || (navigator as any).mozConnection;
+    const connection_type: string = conn?.effectiveType ?? 'safari';
+    void apiClient.patch(BACKEND_ROUTES.auth.connection, { connection_type });
+  }, [isAuth]);
+
   // SSE — recibe session_expired del backend en lugar de hacer polling periódico
   useEffect(() => {
     if (!isAuth) return;


### PR DESCRIPTION
- Parse User-Agent on login to detect device type, vendor/model, OS, and browser
- Report connection type (4g/3g/safari/etc.) from frontend once per session
- Cache all stats in-memory and flush to DB every 6h via atomic UPSERT increment
- New tables: analytics_device_stats (simple key/count) and analytics_client_stats (structured columns)
- Flush included in SIGTERM handler alongside existing activity cache