### PR TITLE
fix(analytics): migrate Speed Insights and Analytics to React components for route attribution

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - 2026-04-09
+
+#### Observability — Speed Insights y Analytics migrados a componentes React
+
+- **`src/main.tsx`**: Elimina `injectSpeedInsights()` e `inject()` (imperativo). Estas llamadas estaban fuera del contexto del router, causando que todas las visitas aparecieran como "Unknown" en Vercel Speed Insights.
+- **`src/pages/App.tsx`**: Agrega `<SpeedInsights />` de `@vercel/speed-insights/react` y `<Analytics />` de `@vercel/analytics/react` como siblings de `<RouterProvider>`. Al estar en el árbol de React con acceso al History API, ambos componentes capturan correctamente la ruta activa en cada navegación.
+
 ### Changed - 2026-04-07
 
 #### Auth — SSE reemplaza polling periódico de sesión

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,11 +2,6 @@ import { createRoot } from 'react-dom/client';
 
 import './styles/index.css';
 import App from './pages/App.tsx';
-import { injectSpeedInsights } from '@vercel/speed-insights';
- import { inject } from "@vercel/analytics"
-
-injectSpeedInsights();
-inject()
 
 // Reload once when a dynamic import fails due to stale chunk hashes after a new deploy.
 window.addEventListener('vite:preloadError', () => {

--- a/web/src/pages/App.tsx
+++ b/web/src/pages/App.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from '../providers/theme-provider';
 import { RoutesContent } from '../routes/route';
 import { AuthProvider } from '@/providers/AuthProvider';
 import { ConditionalProviders } from '@/providers/ConditionalProviders';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+import { Analytics } from '@vercel/analytics/react';
 
 const router = createBrowserRouter(RoutesContent);
 export const queryClient = new QueryClient({
@@ -28,6 +30,8 @@ function App() {
           <ConditionalProviders>
             <Toaster position="bottom-center" />
             <RouterProvider router={router} />
+            <SpeedInsights />
+            <Analytics />
           </ConditionalProviders>
         </ThemeProvider>
       </AuthProvider>


### PR DESCRIPTION


Replaces imperative injectSpeedInsights()/inject() calls in main.tsx with <SpeedInsights /> and <Analytics /> React components placed inside App.tsx. This enables proper route tracking — previously all visits appeared as "Unknown" in Vercel Speed Insights because the SDK had no access to the router context.