### PR TITLE
refactor(api): move cache logic from routes to controllers

### DIFF
--- a/api/src/cache/cacheInvalidation.ts
+++ b/api/src/cache/cacheInvalidation.ts
@@ -100,6 +100,21 @@ export function invalidateOrgNetworkIds(organization_id: string): void {
   globalCacheManager.invalidate(`org:${organization_id}:network-ids`);
 }
 
+// ====== Organization cache keys ======
+
+export function getOrganizationAllCacheKey(): string {
+  return 'organizations:all';
+}
+
+export function getOrganizationChildrenCacheKey(parentOrgId: string): string {
+  return `org:${parentOrgId}:children`;
+}
+
+export function invalidateOrganizations(): void {
+  globalCacheManager.invalidate(getOrganizationAllCacheKey());
+  globalCacheManager.invalidateMatching(/^org:[^:]+:children$/);
+}
+
 /**
  * Nuclear option: invalidate all caches for an organization
  * Use when you need to ensure complete cache refresh
@@ -109,6 +124,7 @@ export function invalidateAllForOrg(organization_id: string): void {
   invalidateSchedulesForOrg(organization_id);
   invalidateScheduleLotteriesForOrg(organization_id);
   invalidateOrgNetworkIds(organization_id);
+  invalidateOrganizations();
 }
 
 /**

--- a/api/src/lottery/controller/lottery.controller.ts
+++ b/api/src/lottery/controller/lottery.controller.ts
@@ -10,6 +10,12 @@ import { parseLottery } from '../helper/parseLottery';
 import { ILotteryEntityFront } from '@helper/types/lottery.type';
 import { SCHEDULE_DAY } from '@helper/types/schedule-lottery.type';
 import { ScheduleLotteryController } from '../../schedule-lottery/controller/schedule-lottery.controller';
+import { globalCacheManager } from 'src/cache/CacheManager';
+import {
+  getLotteryCacheKey,
+  getLotteryDayCacheKey,
+  invalidateLotteryRelated,
+} from 'src/cache/cacheInvalidation';
 
 export class LotteryController {
   private repository = new LotteryRepository();
@@ -17,16 +23,17 @@ export class LotteryController {
 
   create = async (props: INewLotteryEntity, organization_id: string) => {
     try {
-      // If order is not provided, get the next available order
       const order = props.order ?? (await this.repository.getNextOrder(organization_id));
       const newLottery = lotteryBase({ ...props, order }, organization_id);
       const result = await this.repository.create(newLottery);
+      invalidateLotteryRelated(organization_id);
       return parseLottery(result);
     } catch (error) {
       console.error('Creation error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
     }
   };
+
   get = async (props: IGetLotteryEntity, organization_id: string): Promise<ILotteryEntityFront> => {
     try {
       const lottery = await this.repository.getById(props.lottery_id, organization_id);
@@ -39,11 +46,12 @@ export class LotteryController {
 
   getAll = async (all?: boolean, organization_id?: string): Promise<ILotteryEntityFront[]> => {
     try {
-      const lotterys = await this.repository.getAll(organization_id!, all);
-
-      return lotterys.map((lottery) => {
-        return parseLottery(lottery);
+      const key = getLotteryCacheKey(organization_id!, all ?? false);
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const lotterys = await this.repository.getAll(organization_id!, all);
+        return lotterys.map(parseLottery);
       });
+      return snap.payload;
     } catch (error) {
       console.error('GetAll error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -56,21 +64,18 @@ export class LotteryController {
     organization_id: string
   ): Promise<ILotteryEntityFront[]> => {
     try {
-      // Get lottery IDs that are configured for this day
-      const lotteryIds = await this.scheduleLotteryController.getLotteryIdsForDay(
-        organization_id,
-        day
-      );
-
-      // Get all lotteries
-      const allLotteries = await this.repository.getAll(organization_id, all);
-
-      // Filter lotteries by IDs that are configured for this day
-      const filteredLotteries = allLotteries.filter((lottery) =>
-        lotteryIds.includes(lottery.lottery_id)
-      );
-
-      return filteredLotteries.map((lottery) => parseLottery(lottery));
+      const key = getLotteryDayCacheKey(organization_id, day, all);
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const lotteryIds = await this.scheduleLotteryController.getLotteryIdsForDay(
+          organization_id,
+          day
+        );
+        const allLotteries = await this.repository.getAll(organization_id, all);
+        return allLotteries
+          .filter((lottery) => lotteryIds.includes(lottery.lottery_id))
+          .map(parseLottery);
+      });
+      return snap.payload;
     } catch (error) {
       console.error('getAllByDay error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -84,16 +89,18 @@ export class LotteryController {
   ): Promise<ILotteryEntityFront> => {
     try {
       const lottery = await this.repository.update(id, props, organization_id);
+      invalidateLotteryRelated(organization_id);
       return parseLottery(lottery);
     } catch (error) {
       console.error('Update error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
     }
   };
+
   delete = async (props: IDeleteLotteryEntity, organization_id: string) => {
     try {
       await this.repository.delete(props.lottery_id, organization_id);
-      return;
+      invalidateLotteryRelated(organization_id);
     } catch (error) {
       console.error('Delete error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');

--- a/api/src/lottery/route/lottery.route.ts
+++ b/api/src/lottery/route/lottery.route.ts
@@ -6,22 +6,12 @@ import { ERROR_MESSAGE, ERROR_TYPE } from '@helper/types/errors.type';
 import { USER_TYPE } from '@helper/types/user.type';
 import { ILotteryEntityFront } from '@helper/types/lottery.type';
 import { updateLotterySchema } from '@helper/schemas/lottery.schema';
-import { globalCacheManager } from 'src/cache/CacheManager';
-import {
-  getLotteryCacheKey,
-  getLotteryDayCacheKey,
-  invalidateLotteryRelated,
-} from 'src/cache/cacheInvalidation';
 import { SCHEDULE_DAY } from '@helper/types/schedule-lottery.type';
-
-// ====== Cache Manager para Lotteries ======
-function keyFor(organization_id: string, allFlag: boolean) {
-  return getLotteryCacheKey(organization_id, allFlag);
-}
 
 export class LotteryRouter {
   public router: Router;
   private controller: LotteryController;
+
   constructor() {
     this.router = Router();
     this.controller = new LotteryController();
@@ -29,7 +19,6 @@ export class LotteryRouter {
   }
 
   private setupRoutes() {
-    // this.router.get('/:id', this.controller.get);
     this.router.get('/', this.getAllLotteryHandler);
     this.router.post('/', this.newLotteryHandler);
     this.router.put('/:id', this.updateLotteryHandler);
@@ -47,6 +36,7 @@ export class LotteryRouter {
       res.status(400).json(response);
       return;
     }
+
     if ([USER_TYPE.CASHIER, USER_TYPE.ADMIN].includes(user?.user.user_type as USER_TYPE)) {
       const response: APIResponse<undefined> = {
         error: { error: ERROR_TYPE.FORBIDDEN, message: ERROR_MESSAGE.FORBIDDEN },
@@ -57,27 +47,13 @@ export class LotteryRouter {
 
     try {
       const lottery = await this.controller.create({ name }, req.organization_id!);
-
-      // invalidación (ambas variantes all=true/false)
-      invalidateLotteryRelated(req.organization_id!);
-
       const response: APIResponse<ILotteryEntityFront> = { data: { lottery } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -87,96 +63,39 @@ export class LotteryRouter {
     const dayParam = req.query.day as string | undefined;
 
     if (!user?.user) {
-      const response: APIResponse<null> = {
+      res.status(500).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST },
-      };
-      res.status(500).json(response);
+      });
       return;
     }
 
-    // Validate day parameter if provided
     let day: SCHEDULE_DAY | undefined;
     if (dayParam) {
       if (!(dayParam in SCHEDULE_DAY)) {
-        const response: APIResponse<null> = {
+        res.status(400).json({
           error: {
             error: ERROR_TYPE.BAD_REQUEST,
             message: `Invalid day parameter: ${dayParam}. Must be one of: SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY`,
           },
-        };
-        res.status(400).json(response);
+        });
         return;
       }
       day = SCHEDULE_DAY[dayParam as keyof typeof SCHEDULE_DAY];
     }
 
     try {
-      // If day filter is provided, fetch filtered lotteries with server-side cache
-      if (day !== undefined) {
-        const dayKey = getLotteryDayCacheKey(req.organization_id!, day, allFlag);
-        const snap = await globalCacheManager.getOrLoad(
-          dayKey,
-          () => this.controller.getAllByDay(day!, allFlag, req.organization_id!),
-          { ttl: 60_000, etagStrategy: 'counter' }
-        );
+      const lottery =
+        day !== undefined
+          ? await this.controller.getAllByDay(day, allFlag, req.organization_id!)
+          : await this.controller.getAll(allFlag, req.organization_id);
 
-        const inm = req.headers['if-none-match'];
-        if (inm && inm === snap.etag) {
-          res.status(304).end();
-          return;
-        }
-
-        const response: APIResponse<ILotteryEntityFront[]> = {
-          data: { lottery: snap.payload },
-        };
-        res.setHeader('ETag', snap.etag);
-        res.setHeader('Cache-Control', 'private, no-cache');
-        res.status(200).json(response);
-        return;
-      }
-
-      // Original caching logic for non-filtered queries
-      const key = keyFor(req.organization_id!, allFlag);
-      const snap = await globalCacheManager.getOrLoad(
-        key,
-        () => this.controller.getAll(allFlag, req.organization_id),
-        {
-          etagStrategy: 'timestamp',
-        }
-      );
-
-      // 304 si el cliente tiene la misma versión
-      const inm = req.headers['if-none-match'];
-      if (inm && inm === snap.etag) {
-        res.status(304).end();
-        return;
-      }
-
-      const response: APIResponse<ILotteryEntityFront[]> = {
-        data: { lottery: snap.payload },
-      };
-
-      // "sin TTL": forzá revalidación de cliente/proxy via ETag
-      // (el ETag sólo cambia en mutaciones)
-      res.setHeader('ETag', snap.etag);
-      res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
-
+      const response: APIResponse<ILotteryEntityFront[]> = { data: { lottery } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -195,35 +114,21 @@ export class LotteryRouter {
 
     const result = updateLotterySchema.safeParse(updateLottery);
     if (!result.success) {
-      const response: APIResponse<undefined> = {
+      res.status(400).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: String(result.error.message) },
-      };
-      res.status(400).json(response);
+      });
       return;
     }
 
     try {
       const lottery = await this.controller.update(lottery_id, updateLottery, req.organization_id!);
-
-      invalidateLotteryRelated(req.organization_id!);
-
       const response: APIResponse<ILotteryEntityFront> = { data: { lottery } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -241,25 +146,12 @@ export class LotteryRouter {
 
     try {
       await this.controller.delete({ lottery_id }, req.organization_id!);
-
-      invalidateLotteryRelated(req.organization_id!);
-
       res.status(200).json({ data: { deleted: true } });
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 }

--- a/api/src/organization/controller/organization.controller.ts
+++ b/api/src/organization/controller/organization.controller.ts
@@ -5,6 +5,12 @@ import { INewOrganizationEntity } from '@helper/request/organization.request';
 import { INewUserEntity } from '@helper/request/user.request';
 import { UserController } from '../../user/controller/user.controller';
 import { USER_TYPE } from '@helper/types/user.type';
+import { globalCacheManager } from 'src/cache/CacheManager';
+import {
+  getOrganizationAllCacheKey,
+  getOrganizationChildrenCacheKey,
+  invalidateOrganizations,
+} from 'src/cache/cacheInvalidation';
 
 export class OrganizationController {
   private repository = new OrganizationRepository();
@@ -20,17 +26,13 @@ export class OrganizationController {
     capitalistData: INewUserEntity
   ): Promise<IOrganizationEntityFront> => {
     try {
-      // Ensure the user is created as CAPITALIST
       capitalistData.user_type = USER_TYPE.CAPITALIST;
 
-      // 1. Create the organization first
       const createdOrganization = await this.repository.create(organizationData);
 
-      // 2. Create the CAPITALIST user with the organization_id
       try {
         await this.userController.create(capitalistData, createdOrganization.organization_id);
       } catch (userError) {
-        // If user creation fails, delete the organization (rollback)
         await this.repository.delete(createdOrganization.organization_id);
         console.error('Capitalist creation error, organization rolled back:', userError);
         throw new Error(
@@ -39,6 +41,7 @@ export class OrganizationController {
         );
       }
 
+      invalidateOrganizations();
       return parseOrganization(createdOrganization);
     } catch (error) {
       console.error('Organization creation error:', error);
@@ -57,23 +60,19 @@ export class OrganizationController {
     superAdminData?: INewUserEntity
   ): Promise<IOrganizationEntityFront> => {
     try {
-      // 1. Create the sub-organization
       const createdOrg = await this.repository.createSubOrganization({
         name: organizationData.name,
         parent_organization_id: parentOrgId,
       });
 
       try {
-        // 2. Inherit configuration from parent (lotteries, schedules, schedule_lotteries)
         await this.repository.inheritConfiguration(parentOrgId, createdOrg.organization_id);
 
-        // 3. Create SUPERADMIN if provided
         if (superAdminData) {
           superAdminData.user_type = USER_TYPE.SUPERADMIN;
           await this.userController.create(superAdminData, createdOrg.organization_id);
         }
       } catch (setupError) {
-        // If setup fails, delete the sub-organization (rollback)
         await this.repository.delete(createdOrg.organization_id);
         console.error('Sub-organization setup error, rolled back:', setupError);
         throw new Error(
@@ -82,6 +81,7 @@ export class OrganizationController {
         );
       }
 
+      invalidateOrganizations();
       return parseOrganization(createdOrg);
     } catch (error) {
       console.error('Sub-organization creation error:', error);
@@ -94,8 +94,12 @@ export class OrganizationController {
    */
   getChildren = async (parentOrgId: string): Promise<IOrganizationEntityFront[]> => {
     try {
-      const children = await this.repository.getChildren(parentOrgId);
-      return children.map((org) => parseOrganization(org));
+      const key = getOrganizationChildrenCacheKey(parentOrgId);
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const children = await this.repository.getChildren(parentOrgId);
+        return children.map(parseOrganization);
+      });
+      return snap.payload;
     } catch (error) {
       console.error('Organization getChildren error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -114,8 +118,12 @@ export class OrganizationController {
 
   getAll = async (): Promise<IOrganizationEntityFront[]> => {
     try {
-      const orgs = await this.repository.getAll();
-      return orgs.map((org) => parseOrganization(org));
+      const key = getOrganizationAllCacheKey();
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const orgs = await this.repository.getAll();
+        return orgs.map(parseOrganization);
+      });
+      return snap.payload;
     } catch (error) {
       console.error('Organization getAll error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -128,6 +136,7 @@ export class OrganizationController {
   ): Promise<IOrganizationEntityFront> => {
     try {
       const org = await this.repository.update(id, props);
+      invalidateOrganizations();
       return parseOrganization(org);
     } catch (error) {
       console.error('Organization update error:', error);
@@ -138,6 +147,7 @@ export class OrganizationController {
   delete = async (organization_id: string): Promise<void> => {
     try {
       await this.repository.delete(organization_id);
+      invalidateOrganizations();
     } catch (error) {
       console.error('Organization delete error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');

--- a/api/src/schedule-lottery/controller/schedule-lottery.controller.ts
+++ b/api/src/schedule-lottery/controller/schedule-lottery.controller.ts
@@ -5,12 +5,22 @@ import {
   IScheduleLotteryEntityFront,
   SCHEDULE_DAY,
 } from '@helper/types/schedule-lottery.type';
+import { globalCacheManager } from 'src/cache/CacheManager';
+import {
+  getScheduleLotteryCacheKey,
+  invalidateScheduleLotteryRelated,
+} from 'src/cache/cacheInvalidation';
 
 export class ScheduleLotteryController {
   private repository = new ScheduleLotteryRepository();
+
   async getAllScheduleLotteries(organization_id: string): Promise<IScheduleLotteryEntityFront> {
-    const response = await this.repository.getAllScheduleLottery(organization_id);
-    return parseScheduleLottery(response);
+    const key = getScheduleLotteryCacheKey(organization_id);
+    const snap = await globalCacheManager.getOrLoad(key, async () => {
+      const response = await this.repository.getAllScheduleLottery(organization_id);
+      return parseScheduleLottery(response);
+    });
+    return snap.payload;
   }
 
   async deleteAllForScheduleAndDay({
@@ -45,17 +55,19 @@ export class ScheduleLotteryController {
   ): Promise<IScheduleLotteryEntityFront> {
     try {
       await this.repository.bulkInsert(props);
+      invalidateScheduleLotteryRelated(organization_id);
       return await this.getAllScheduleLotteries(organization_id);
     } catch (error) {
       console.error('bulkInsert:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
     }
   }
+
   async bulkActiveLotteries(lotteries: string[], organization_id: string): Promise<void> {
     try {
       await this.repository.bulkActiveLotteries(lotteries, organization_id);
     } catch (error) {
-      console.error('bulkInsert:', error);
+      console.error('bulkActiveLotteries:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
     }
   }
@@ -65,10 +77,8 @@ export class ScheduleLotteryController {
     organization_id: string
   ): Promise<IScheduleLotteryEntityFront> {
     try {
-      // Use RPC function for atomic save
       await this.repository.saveScheduleLottery(scheduleLottery, organization_id);
 
-      // Extract all lottery IDs to activate
       const lotteries: string[] = [];
       for (const daySchedules of Object.values(scheduleLottery)) {
         for (const lotteryIds of Object.values(daySchedules ?? {})) {
@@ -78,12 +88,11 @@ export class ScheduleLotteryController {
         }
       }
 
-      // Activate lotteries
       if (lotteries.length > 0) {
         await this.repository.bulkActiveLotteries(lotteries, organization_id);
       }
 
-      // Return fresh data
+      invalidateScheduleLotteryRelated(organization_id);
       return await this.getAllScheduleLotteries(organization_id);
     } catch (error) {
       console.error('saveScheduleLottery:', error);
@@ -106,9 +115,7 @@ export class ScheduleLotteryController {
   async getLotteryIdsForDay(organization_id: string, day: SCHEDULE_DAY): Promise<string[]> {
     try {
       const records = await this.repository.getScheduleLotteriesByDay(organization_id, day);
-      const lotteryIds = records.map((record) => record.lottery_id);
-      // Return unique lottery IDs
-      return [...new Set(lotteryIds)];
+      return [...new Set(records.map((record) => record.lottery_id))];
     } catch (error) {
       console.error('getLotteryIdsForDay:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -118,9 +125,7 @@ export class ScheduleLotteryController {
   async getScheduleIdsForDay(organization_id: string, day: SCHEDULE_DAY): Promise<string[]> {
     try {
       const records = await this.repository.getScheduleLotteriesByDay(organization_id, day);
-      const scheduleIds = records.map((record) => record.schedule_id);
-      // Return unique schedule IDs
-      return [...new Set(scheduleIds)];
+      return [...new Set(records.map((record) => record.schedule_id))];
     } catch (error) {
       console.error('getScheduleIdsForDay:', error);
       throw error instanceof Error ? error : new Error('Unknown error');

--- a/api/src/schedule-lottery/route/schedule-lottery.route.ts
+++ b/api/src/schedule-lottery/route/schedule-lottery.route.ts
@@ -4,22 +4,10 @@ import { ERROR_MESSAGE, ERROR_TYPE } from '@helper/types/errors.type';
 import { USER_TYPE } from '@helper/types/user.type';
 import { ScheduleLotteryController } from '../controller/schedule-lottery.controller';
 import { IScheduleLotteryEntityFront, SCHEDULE_DAY } from '@helper/types/schedule-lottery.type';
-import { globalCacheManager } from 'src/cache/CacheManager';
-import {
-  getScheduleLotteryCacheKey,
-  invalidateScheduleLotteryRelated,
-} from 'src/cache/cacheInvalidation';
 
 export type ScheduleLotteryPayload = {
   scheduleLotteries: IScheduleLotteryEntityFront;
 };
-
-// ====== Cache Manager para Schedule Lotteries ======
-const TTL_MS = 24 * 60 * 60 * 1000; // 1 dia
-
-function getCacheKey(organization_id: string) {
-  return getScheduleLotteryCacheKey(organization_id);
-}
 
 export class ScheduleLotteryRouter {
   public router: Router;
@@ -36,45 +24,37 @@ export class ScheduleLotteryRouter {
     this.router.get('/', this.getScheduleLotteryHandler);
   }
 
-  // ====== POST: guarda e invalida cache ======
   private newScheduleLotteryHandler: RequestHandler = async (req: Request, res: Response) => {
     const { user } = req;
     const { scheduleLottery } = req.body;
 
     if ([USER_TYPE.CASHIER, USER_TYPE.ADMIN].includes(user?.user.user_type as USER_TYPE)) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.FORBIDDEN, message: ERROR_MESSAGE.FORBIDDEN },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
 
-    // Validate request payload
     if (!scheduleLottery || typeof scheduleLottery !== 'object') {
-      const response: APIResponse<null> = {
+      res.status(400).json({
         error: {
           error: ERROR_TYPE.BAD_REQUEST,
           message: 'scheduleLottery is required and must be an object',
         },
-      };
-      res.status(400).json(response);
+      });
       return;
     }
 
-    // UUID regex pattern
     const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-    // Validate day keys, schedule_ids, and lottery_ids
     for (const dayKey of Object.keys(scheduleLottery)) {
-      // Validate day key is a valid SCHEDULE_DAY enum value
       if (!(dayKey in SCHEDULE_DAY)) {
-        const response: APIResponse<null> = {
+        res.status(400).json({
           error: {
             error: ERROR_TYPE.BAD_REQUEST,
             message: `Invalid day key: ${dayKey}. Must be one of: SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY`,
           },
-        };
-        res.status(400).json(response);
+        });
         return;
       }
 
@@ -82,40 +62,35 @@ export class ScheduleLotteryRouter {
       if (!schedules || typeof schedules !== 'object') continue;
 
       for (const scheduleId of Object.keys(schedules)) {
-        // Validate schedule_id is a valid UUID
         if (!uuidPattern.test(scheduleId)) {
-          const response: APIResponse<null> = {
+          res.status(400).json({
             error: {
               error: ERROR_TYPE.BAD_REQUEST,
               message: `Invalid schedule_id format: ${scheduleId}. Must be a valid UUID`,
             },
-          };
-          res.status(400).json(response);
+          });
           return;
         }
 
         const lotteries = schedules[scheduleId];
         if (!Array.isArray(lotteries)) {
-          const response: APIResponse<null> = {
+          res.status(400).json({
             error: {
               error: ERROR_TYPE.BAD_REQUEST,
               message: `Lotteries for schedule ${scheduleId} must be an array`,
             },
-          };
-          res.status(400).json(response);
+          });
           return;
         }
 
-        // Validate each lottery_id is a valid UUID
         for (const lotteryId of lotteries) {
           if (!uuidPattern.test(lotteryId)) {
-            const response: APIResponse<null> = {
+            res.status(400).json({
               error: {
                 error: ERROR_TYPE.BAD_REQUEST,
                 message: `Invalid lottery_id format: ${lotteryId}. Must be a valid UUID`,
               },
-            };
-            res.status(400).json(response);
+            });
             return;
           }
         }
@@ -123,75 +98,31 @@ export class ScheduleLotteryRouter {
     }
 
     try {
-      // Use controller's saveScheduleLottery method for atomic save
       const data = await this.controller.saveScheduleLottery(scheduleLottery, req.organization_id!);
-
-      // Invalidate cache after successful save
-      invalidateScheduleLotteryRelated(req.organization_id!);
-
       const response: APIResponse<IScheduleLotteryEntityFront> = {
         data: { scheduleLotteries: data },
       };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        ) {
-          statusCode = 401;
-        }
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
-  // ====== GET: sirve desde cache + ETag/304 ======
   private getScheduleLotteryHandler: RequestHandler = async (req: Request, res: Response) => {
     try {
-      const snap = await globalCacheManager.getOrLoad(
-        getCacheKey(req.organization_id!),
-        () => this.controller.getAllScheduleLotteries(req.organization_id!),
-        { ttl: TTL_MS, etagStrategy: 'hash' }
-      );
-
-      // Soporta If-None-Match para 304 (ahorra ancho de banda y CPU)
-      const inm = req.headers['if-none-match'];
-      if (inm && inm === snap.etag) {
-        res.status(304).end();
-        return;
-      }
-
+      const scheduleLotteries = await this.controller.getAllScheduleLotteries(req.organization_id!);
       const response: APIResponse<IScheduleLotteryEntityFront> = {
-        data: { scheduleLotteries: snap.payload },
+        data: { scheduleLotteries },
       };
-
-      // Cache-Control/ETag para clientes/proxies (CDN opcional)
-      res.setHeader('ETag', snap.etag);
-      // max-age para clientes; stale-while-revalidate para proxies/CDN modernos
-      res.setHeader('Cache-Control', 'public, max-age=60, stale-while-revalidate=300');
-
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        ) {
-          statusCode = 401;
-        }
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 }

--- a/api/src/shcedule/controller/schedule.controller.ts
+++ b/api/src/shcedule/controller/schedule.controller.ts
@@ -10,6 +10,12 @@ import { scheduleBase } from '../helper/scheduleBase';
 import { parseSchedule } from '../helper/parseSchedule';
 import { SCHEDULE_DAY } from '@helper/types/schedule-lottery.type';
 import { ScheduleLotteryController } from '../../schedule-lottery/controller/schedule-lottery.controller';
+import { globalCacheManager } from 'src/cache/CacheManager';
+import {
+  getScheduleCacheKey,
+  getScheduleDayCacheKey,
+  invalidateScheduleRelated,
+} from 'src/cache/cacheInvalidation';
 
 export class ScheduleController {
   private repository = new ScheduleRepository();
@@ -22,6 +28,7 @@ export class ScheduleController {
     try {
       const newSchedule = scheduleBase(props, organization_id);
       const schedule = await this.repository.create(newSchedule);
+      invalidateScheduleRelated(organization_id);
       return parseSchedule(schedule);
     } catch (error) {
       console.error('Controller creation error:', error);
@@ -44,11 +51,12 @@ export class ScheduleController {
 
   getAll = async (organization_id: string, all?: boolean): Promise<IScheduleEntityFront[]> => {
     try {
-      const schedules: IScheduleEntityBack[] = await this.repository.getAll(organization_id, all);
-
-      return schedules.map((schedule) => {
-        return parseSchedule(schedule);
+      const key = getScheduleCacheKey(organization_id, all ?? false);
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const schedules: IScheduleEntityBack[] = await this.repository.getAll(organization_id, all);
+        return schedules.map(parseSchedule);
       });
+      return snap.payload;
     } catch (error) {
       console.error('GetAll error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -62,33 +70,35 @@ export class ScheduleController {
     withLotteries: boolean = false
   ): Promise<IScheduleEntityFront[]> => {
     try {
-      // Fetch schedule_lotteries for the day and all schedules in parallel (2 queries total)
-      const [slRecords, allSchedules] = await Promise.all([
-        this.scheduleLotteryController.getScheduleLotteriesForDay(organization_id, day),
-        this.repository.getAll(organization_id, all),
-      ]);
+      const key = getScheduleDayCacheKey(organization_id, day, all, withLotteries);
+      const snap = await globalCacheManager.getOrLoad(key, async () => {
+        const [slRecords, allSchedules] = await Promise.all([
+          this.scheduleLotteryController.getScheduleLotteriesForDay(organization_id, day),
+          this.repository.getAll(organization_id, all),
+        ]);
 
-      // Build lookup structures from the already-fetched records — no extra queries needed
-      const scheduleIdSet = new Set(slRecords.map((r) => r.schedule_id));
-      const lotteryIdsBySchedule = new Map<string, string[]>();
-      for (const r of slRecords) {
-        const ids = lotteryIdsBySchedule.get(r.schedule_id) ?? [];
-        ids.push(r.lottery_id);
-        lotteryIdsBySchedule.set(r.schedule_id, ids);
-      }
+        const scheduleIdSet = new Set(slRecords.map((r) => r.schedule_id));
+        const lotteryIdsBySchedule = new Map<string, string[]>();
+        for (const r of slRecords) {
+          const ids = lotteryIdsBySchedule.get(r.schedule_id) ?? [];
+          ids.push(r.lottery_id);
+          lotteryIdsBySchedule.set(r.schedule_id, ids);
+        }
 
-      const parsedSchedules = allSchedules
-        .filter((s) => scheduleIdSet.has(s.schedule_id))
-        .map((s) => parseSchedule(s));
+        const parsedSchedules = allSchedules
+          .filter((s) => scheduleIdSet.has(s.schedule_id))
+          .map((s) => parseSchedule(s));
 
-      if (withLotteries) {
-        return parsedSchedules.map((schedule) => ({
-          ...schedule,
-          lottery_ids: lotteryIdsBySchedule.get(schedule.schedule_id) ?? [],
-        }));
-      }
+        if (withLotteries) {
+          return parsedSchedules.map((schedule) => ({
+            ...schedule,
+            lottery_ids: lotteryIdsBySchedule.get(schedule.schedule_id) ?? [],
+          }));
+        }
 
-      return parsedSchedules;
+        return parsedSchedules;
+      });
+      return snap.payload;
     } catch (error) {
       console.error('getAllByDay error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
@@ -102,16 +112,18 @@ export class ScheduleController {
   ): Promise<IScheduleEntityFront> => {
     try {
       const schedule = await this.repository.update(id, props, organization_id);
+      invalidateScheduleRelated(organization_id);
       return parseSchedule(schedule);
     } catch (error) {
       console.error('Update error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');
     }
   };
+
   delete = async (props: IDeleteScheduleEntity, organization_id: string) => {
     try {
       await this.repository.delete(props.schedule_id, organization_id);
-      return;
+      invalidateScheduleRelated(organization_id);
     } catch (error) {
       console.error('Delete error:', error);
       throw error instanceof Error ? error : new Error('Unknown error');

--- a/api/src/shcedule/route/schedule.route.ts
+++ b/api/src/shcedule/route/schedule.route.ts
@@ -5,22 +5,10 @@ import { ERROR_MESSAGE, ERROR_TYPE } from '@helper/types/errors.type';
 import { USER_TYPE } from '@helper/types/user.type';
 import { IScheduleEntityFront } from '@helper/types/schedule.type';
 import { newScheduleSchema, updateScheduleSchema } from '@helper/schemas/schedule.schema';
-import { globalCacheManager } from 'src/cache/CacheManager';
-import {
-  getScheduleCacheKey,
-  getScheduleDayCacheKey,
-  invalidateScheduleRelated,
-} from 'src/cache/cacheInvalidation';
 import { SCHEDULE_DAY } from '@helper/types/schedule-lottery.type';
-
-// ====== Cache Manager para Schedules ======
-function getCacheKey(organization_id: string, all: boolean) {
-  return getScheduleCacheKey(organization_id, all);
-}
 
 export class ScheduleRouter {
   public router: Router;
-
   private controller: ScheduleController;
 
   constructor() {
@@ -30,7 +18,6 @@ export class ScheduleRouter {
   }
 
   private setupRoutes() {
-    // this.router.get('/:id', this.getScheduleHandler);
     this.router.get('/', this.getAllScheduleHandler);
     this.router.post('/', this.newSchedulehandler);
     this.router.put('/:id', this.updateScheduleHandler);
@@ -42,48 +29,36 @@ export class ScheduleRouter {
     const { newSchedule } = req.body;
 
     if ([USER_TYPE.CASHIER, USER_TYPE.ADMIN].includes(user?.user.user_type as USER_TYPE)) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.FORBIDDEN, message: ERROR_MESSAGE.FORBIDDEN },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
+
     if (!organization_id) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
 
     const result = newScheduleSchema.safeParse(newSchedule);
     if (!result.success) {
-      const response: APIResponse<undefined> = {
+      res.status(400).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: String(result.error.message) },
-      };
-      res.status(400).json(response);
+      });
       return;
     }
 
     try {
       const schedule = await this.controller.create(newSchedule, req.organization_id!);
-      invalidateScheduleRelated(req.organization_id!);
       const response: APIResponse<IScheduleEntityFront> = { data: { schedule } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -94,89 +69,39 @@ export class ScheduleRouter {
     const withLotteries = req.query.with_lotteries === 'true';
 
     if (!user?.user) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
 
-    // Validate day parameter if provided
     let day: SCHEDULE_DAY | undefined;
     if (dayParam) {
       if (!(dayParam in SCHEDULE_DAY)) {
-        const response: APIResponse<null> = {
+        res.status(400).json({
           error: {
             error: ERROR_TYPE.BAD_REQUEST,
             message: `Invalid day parameter: ${dayParam}. Must be one of: SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY`,
           },
-        };
-        res.status(400).json(response);
+        });
         return;
       }
       day = SCHEDULE_DAY[dayParam as keyof typeof SCHEDULE_DAY];
     }
 
     try {
-      // If day filter is provided, fetch filtered schedules with server-side cache
-      if (day !== undefined) {
-        const dayKey = getScheduleDayCacheKey(req.organization_id!, day, allFlag, withLotteries);
-        const snap = await globalCacheManager.getOrLoad(
-          dayKey,
-          () => this.controller.getAllByDay(day!, allFlag, req.organization_id!, withLotteries),
-          { ttl: 60_000, etagStrategy: 'counter' }
-        );
+      const schedule =
+        day !== undefined
+          ? await this.controller.getAllByDay(day, allFlag, req.organization_id!, withLotteries)
+          : await this.controller.getAll(req.organization_id!, allFlag);
 
-        const inm = req.headers['if-none-match'];
-        if (inm && inm === snap.etag) {
-          res.status(304).end();
-          return;
-        }
-
-        const response: APIResponse<IScheduleEntityFront[]> = {
-          data: { schedule: snap.payload },
-        };
-        res.setHeader('ETag', snap.etag);
-        res.setHeader('Cache-Control', 'private, no-cache');
-        res.status(200).json(response);
-        return;
-      }
-
-      // Original caching logic for non-filtered queries
-      const key = getCacheKey(req.organization_id!, allFlag);
-      const snap = await globalCacheManager.getOrLoad(
-        key,
-        () => this.controller.getAll(req.organization_id!, allFlag),
-        {
-          etagStrategy: 'counter',
-        }
-      );
-
-      // ETag/304: si el cliente tiene la versión actual, no enviamos payload
-      const inm = req.headers['if-none-match'];
-      if (inm && inm === snap.etag) {
-        res.status(304).end();
-        return;
-      }
-
-      const response: APIResponse<IScheduleEntityFront[]> = { data: { schedule: snap.payload } };
-      res.setHeader('ETag', snap.etag);
-      res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate'); // sin TTL
+      const response: APIResponse<IScheduleEntityFront[]> = { data: { schedule } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -186,19 +111,17 @@ export class ScheduleRouter {
     const { updateSchedule } = req.body;
 
     if ([USER_TYPE.CASHIER, USER_TYPE.ADMIN].includes(user?.user.user_type as USER_TYPE)) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.FORBIDDEN, message: ERROR_MESSAGE.FORBIDDEN },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
 
     const result = updateScheduleSchema.safeParse(updateSchedule);
     if (!result.success) {
-      const response: APIResponse<undefined> = {
+      res.status(400).json({
         error: { error: ERROR_TYPE.BAD_REQUEST, message: String(result.error.message) },
-      };
-      res.status(400).json(response);
+      });
       return;
     }
 
@@ -208,23 +131,13 @@ export class ScheduleRouter {
         updateSchedule,
         req.organization_id!
       );
-      invalidateScheduleRelated(req.organization_id!);
       const response: APIResponse<IScheduleEntityFront> = { data: { schedule } };
       res.status(200).json(response);
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 
@@ -233,31 +146,20 @@ export class ScheduleRouter {
     const { id: schedule_id } = req.params;
 
     if ([USER_TYPE.CASHIER, USER_TYPE.ADMIN].includes(user?.user.user_type as USER_TYPE)) {
-      const response: APIResponse<undefined> = {
+      res.status(403).json({
         error: { error: ERROR_TYPE.FORBIDDEN, message: ERROR_MESSAGE.FORBIDDEN },
-      };
-      res.status(403).json(response);
+      });
       return;
     }
 
     try {
       await this.controller.delete({ schedule_id }, req.organization_id!);
-      invalidateScheduleRelated(req.organization_id!);
       res.status(200).json({ data: { deleted: true } });
     } catch (error) {
       console.error(error);
-      if (error instanceof Error) {
-        let statusCode = 500;
-        if (
-          error.message === ERROR_MESSAGE.USER_NOT_FOUND ||
-          error.message === ERROR_MESSAGE.INVALID_CREDENTIALS
-        )
-          statusCode = 401;
-        const response: APIResponse<null> = {
-          error: { error: ERROR_TYPE.AUTH_ERROR, message: error.message },
-        };
-        res.status(statusCode).json(response);
-      }
+      res.status(500).json({
+        error: { error: ERROR_TYPE.AUTH_ERROR, message: (error as Error).message },
+      });
     }
   };
 }


### PR DESCRIPTION
Cache now lives in the controller layer, storing parsed EntityFront objects directly. Routes are clean HTTP handlers with no cache knowledge. Invalidation on mutations (create/update/delete) is co-located with the operation that changes the data.

- lottery: getAll, getAllByDay cached; invalidation on create/update/delete
- schedule: getAll, getAllByDay cached; invalidation on create/update/delete
- schedule-lottery: getAllScheduleLotteries cached; invalidation on save/bulkInsert
- organization: getAll, getChildren cached; invalidation on create/update/delete
- cacheInvalidation: add getOrganizationAllCacheKey, getOrganizationChildrenCacheKey, invalidateOrganizations