### PR TITLE
fix(auth): replace SSE with periodic polling to fix Vercel 500 errors

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed - 2026-04-13
+
+#### Auth — eliminar endpoint SSE `/api/private/auth/stream`
+
+- **`src/auth/route/auth.route.ts`**: Eliminado el route `GET /stream` y el handler `sessionStreamHandler`. La SSE no es compatible con Vercel serverless (timeout de 10s en Hobby, 5 min en Pro). El frontend ahora usa polling periódico vía `/validate`. También eliminado el import de `sseManager`.
+- El archivo `src/session/sse/session-sse.manager.ts` queda sin consumidores activos (puede eliminarse en una limpieza posterior si `sseManager.expire()` no se llama desde ningún otro módulo).
+
 ### Fixed - 2026-04-08
 
 #### Archive — batched processing to fix statement timeout on 1M+ rows

--- a/api/src/auth/route/auth.route.ts
+++ b/api/src/auth/route/auth.route.ts
@@ -6,7 +6,6 @@ import { asyncHandler } from '../../middlewares/error.middleware';
 import { UnauthorizedError } from '@helper/errors';
 import { loginSchema } from '@helper/schemas/auth.schema';
 import { SESSION_CONFIG } from 'api/src/config/session.config';
-import { sseManager } from 'api/src/session/sse/session-sse.manager';
 import { deviceStatsCache } from 'api/src/analytics/cache/device-stats.cache';
 
 const ALLOWED_CONNECTION_TYPES = new Set(['4g', '3g', '2g', 'slow-2g', 'safari', 'unknown']);
@@ -42,7 +41,6 @@ export class AuthRouter {
     this.privateRouter.post('/logout', this.logoutHandler);
     this.privateRouter.post('/logout-all', this.logoutAllHandler);
     this.privateRouter.get('/validate', this.validateHandler);
-    this.privateRouter.get('/stream', this.sessionStreamHandler);
     this.privateRouter.patch('/connection', this.connectionHandler);
   }
 
@@ -207,24 +205,5 @@ export class AuthRouter {
     }
     const response: APIResponse<boolean> = { data: { ok: true } };
     res.status(200).json(response);
-  });
-
-  /**
-   * GET /api/private/auth/stream
-   * SSE stream — pushes session_expired event when session is revoked or expires.
-   * Replaces the periodic polling interval on the frontend.
-   * Passive: does not extend the session sliding window.
-   */
-  private sessionStreamHandler = asyncHandler(async (req: Request, res: Response) => {
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.flushHeaders();
-
-    const sessionId = req.user!.session_id;
-    sseManager.add(sessionId, res);
-    res.write('data: {"type":"connected"}\n\n');
-
-    req.on('close', () => sseManager.remove(sessionId));
   });
 }

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - 2026-04-13
+
+#### Auth — reemplazar SSE con polling periódico
+
+- **`src/providers/AuthProvider.tsx`**: Reemplazado el `useEffect` de SSE (`EventSource`) por un intervalo de polling que llama a `validate()` cada `VALIDATE_INTERVAL_MS` (5 minutos). La SSE generaba `TypeError: terminated` en Vercel porque las serverless functions tienen un máximo de 10s en Hobby y 5 min en Pro — incompatible con conexiones persistentes. El polling detecta igualmente sesiones expiradas o revocadas con latencia máxima de 5 minutos.
+
 ### Changed - 2026-04-11
 
 #### Performance — optimizaciones mobile P99 (FCP/LCP/INP/CLS)

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { IUserEntityFront, USER_TYPE } from '@helper/types/user.type';
 import { AuthContext, AuthContextValue, LoginPayload } from '@/contexts/AuthContext';
 import { BACKEND_ROUTES } from '../../routes/routes';
-import { VALIDATE_ON_VISIBILITY, VISIBILITY_MIN_GAP_MS } from '@helper/config/session.config';
+import { VALIDATE_ON_VISIBILITY, VALIDATE_INTERVAL_MS, VISIBILITY_MIN_GAP_MS } from '@helper/config/session.config';
 import { apiClient, ApiError } from '@/lib/apiClient';
 import { AUTH_EXPIRED_EVENT } from '@/lib/authEvents';
 
@@ -141,28 +141,16 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     void apiClient.patch(BACKEND_ROUTES.auth.connection, { connection_type });
   }, [isAuth]);
 
-  // SSE — recibe session_expired del backend en lugar de hacer polling periódico
+  // Polling periódico — detecta sesión expirada o revocada cada VALIDATE_INTERVAL_MS
   useEffect(() => {
     if (!isAuth) return;
 
-    const es = new EventSource(BACKEND_ROUTES.auth.stream, { withCredentials: true });
+    const interval = window.setInterval(() => {
+      void validate();
+    }, VALIDATE_INTERVAL_MS);
 
-    es.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data) as { type: string };
-        if (data.type === 'session_expired') {
-          queryClient.clear();
-          setSession(null);
-          es.close();
-        }
-      } catch {
-        // ignore malformed messages
-      }
-    };
-
-    // EventSource reconecta automáticamente en caso de error de red
-    return () => es.close();
-  }, [isAuth, setSession, queryClient]);
+    return () => window.clearInterval(interval);
+  }, [isAuth, validate]);
 
   // Auto-refresh de access token (cada 13-14 minutos)
   // Access token expira a los 15 minutos, refrescamos antes


### PR DESCRIPTION
SSE connections on /api/private/auth/stream were failing with TypeError: terminated because Vercel serverless functions terminate after 10s (Hobby) / 5min (Pro) — incompatible with persistent connections.

- Remove GET /stream route and sessionStreamHandler from auth.route.ts
- Replace EventSource useEffect in AuthProvider with setInterval polling every VALIDATE_INTERVAL_MS (5 min) using the existing validate() function