### PR TITLE
fix(api): refactor archive job to process one day at a time

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-04-15
+
+#### Archive job: day-by-day processing
+- **Root cause fixed**: archive job was failing because a single `archive_old_data` SP call processed 1.2M+ rows in one transaction, hitting Supabase's `statement_timeout`. The TS fallback also failed because `.delete().in('bet_id', ids)` with 5000 UUIDs exceeded HTTP URL length limits.
+- **New approach**: TypeScript fetches distinct dates to archive (`get_dates_to_archive` RPC), then loops oldest-to-newest calling `archive_data_by_date(date)` per day. Each call is scoped to one day's data so it never approaches the timeout.
+- **New migration** `20260415080624_archive_by_date.sql`:
+  - Drops `archive_old_bets(INTEGER)`, `archive_old_tickets(INTEGER)`, `archive_old_data(INTEGER)`
+  - Adds `get_dates_to_archive(p_cutoff_date DATE)` — returns `DATE[]` of distinct dates with data before the cutoff
+  - Adds `archive_data_by_date(p_date DATE)` — archives bets then tickets for that date in one transaction, returns `{date, bets_archived, tickets_archived}`
+- **`archive.service.ts`**: rewrote `archiveOldData` to loop by day with per-day try/catch; breaks on first failure and reports which date failed. Removed TS manual fallback (`archiveOldBetsManual`, `archiveOldTicketsManual`, `archiveOldDataManual`).
+- **`cron.service.ts`**: updated result logging to show per-day breakdown and totals.
+
 ### Added - 2026-04-14
 
 #### Ticket Idempotency

--- a/api/src/archive/service/archive.service.ts
+++ b/api/src/archive/service/archive.service.ts
@@ -1,13 +1,22 @@
 import { supabase } from '@database/db.connection';
 import { ActivityDaysRepository } from '../../activity/repository/activity-days.repository';
 
-export interface IArchiveResult {
+export interface IArchiveDayResult {
+  date: string;
+  bets_archived: number;
+  tickets_archived: number;
   success: boolean;
-  message: string;
-  cutoff_date: string | null;
-  archived_count: number;
-  deleted_count: number;
-  days_kept: number;
+}
+
+export interface IArchiveJobResult {
+  success: boolean;
+  cutoff_date: string;
+  days_attempted: number;
+  days_succeeded: number;
+  failed_at?: string;
+  error?: string;
+  days: IArchiveDayResult[];
+  execution_time_ms: number;
 }
 
 export interface IArchiveStats {
@@ -37,76 +46,81 @@ export class ArchiveService {
   }
 
   /**
-   * Archive old bets (older than N active days)
-   * Uses stored procedure if available, fallback to TypeScript implementation
+   * Archive all data older than the cutoff date, one day at a time.
+   * Calls archive_data_by_date RPC per day so no single call can timeout.
+   * Iterates from oldest to newest and stops on the first failure.
    */
-  async archiveOldBets(daysToKeep: number = 2): Promise<IArchiveResult> {
-    try {
-      // Try using stored procedure first (performance optimization)
-      const { data, error } = await supabase.rpc('archive_old_bets', {
-        p_days_to_keep: daysToKeep,
-      });
+  async archiveOldData(daysToKeep: number = 2): Promise<IArchiveJobResult> {
+    const startTime = Date.now();
 
-      if (error) {
-        console.warn('Stored procedure failed, using TypeScript fallback:', error.message);
-        return await this.archiveOldBetsManual(daysToKeep);
-      }
+    const cutoffDate = await this.activityDaysRepo.getCutoffDate(daysToKeep);
 
-      return data as IArchiveResult;
-    } catch (err) {
-      console.error('Error archiving bets:', err);
-      throw err;
+    if (!cutoffDate) {
+      return {
+        success: true,
+        cutoff_date: '',
+        days_attempted: 0,
+        days_succeeded: 0,
+        days: [],
+        execution_time_ms: Date.now() - startTime,
+      };
     }
-  }
 
-  /**
-   * Archive old tickets (older than N active days)
-   * Uses stored procedure if available, fallback to TypeScript implementation
-   */
-  async archiveOldTickets(daysToKeep: number = 2): Promise<IArchiveResult> {
-    try {
-      // Try using stored procedure first (performance optimization)
-      const { data, error } = await supabase.rpc('archive_old_tickets', {
-        p_days_to_keep: daysToKeep,
-      });
+    const { data: dates, error: datesError } = await supabase.rpc('get_dates_to_archive', {
+      p_cutoff_date: cutoffDate,
+    });
 
-      if (error) {
-        console.warn('Stored procedure failed, using TypeScript fallback:', error.message);
-        return await this.archiveOldTicketsManual(daysToKeep);
-      }
-
-      return data as IArchiveResult;
-    } catch (err) {
-      console.error('Error archiving tickets:', err);
-      throw err;
+    if (datesError) {
+      throw new Error(`Failed to get dates to archive: ${datesError.message}`);
     }
-  }
 
-  /**
-   * Archive both bets and tickets in a single operation
-   */
-  async archiveOldData(daysToKeep: number = 2): Promise<{
-    success: boolean;
-    bets: IArchiveResult;
-    tickets: IArchiveResult;
-    execution_time_ms?: number;
-  }> {
-    try {
-      // Try using stored procedure first (more efficient - single transaction)
-      const { data, error } = await supabase.rpc('archive_old_data', {
-        p_days_to_keep: daysToKeep,
-      });
+    const datesToArchive: string[] = dates || [];
+    const results: IArchiveDayResult[] = [];
 
-      if (error) {
-        console.warn('Stored procedure failed, using TypeScript fallback:', error.message);
-        return await this.archiveOldDataManual(daysToKeep);
+    for (const date of datesToArchive) {
+      try {
+        const { data, error } = await supabase.rpc('archive_data_by_date', { p_date: date });
+
+        if (error) throw new Error(error.message);
+
+        const dayResult: IArchiveDayResult = {
+          date,
+          bets_archived: data.bets_archived,
+          tickets_archived: data.tickets_archived,
+          success: true,
+        };
+
+        results.push(dayResult);
+        console.log(
+          `[ArchiveService] ✓ ${date}: ${dayResult.bets_archived} bets, ${dayResult.tickets_archived} tickets`
+        );
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.error(`[ArchiveService] ✗ ${date}: ${errorMsg}`);
+
+        results.push({ date, bets_archived: 0, tickets_archived: 0, success: false });
+
+        return {
+          success: false,
+          cutoff_date: cutoffDate,
+          days_attempted: results.length,
+          days_succeeded: results.filter((r) => r.success).length,
+          failed_at: date,
+          error: errorMsg,
+          days: results,
+          execution_time_ms: Date.now() - startTime,
+        };
       }
-
-      return data;
-    } catch (err) {
-      console.error('Error archiving data:', err);
-      throw err;
     }
+
+    return {
+      success: true,
+      cutoff_date: cutoffDate,
+      days_attempted: results.length,
+      days_succeeded: results.length,
+      days: results,
+      execution_time_ms: Date.now() - startTime,
+    };
   }
 
   /**
@@ -128,194 +142,7 @@ export class ArchiveService {
     }
   }
 
-  /**
-   * Manual implementation of archiving bets (fallback)
-   * Processes in batches to avoid statement timeouts on large tables.
-   */
-  private async archiveOldBetsManual(daysToKeep: number): Promise<IArchiveResult> {
-    const cutoffDate = await this.activityDaysRepo.getCutoffDate(daysToKeep);
-
-    if (!cutoffDate) {
-      return {
-        success: true,
-        message: 'Not enough active days to archive',
-        cutoff_date: null,
-        archived_count: 0,
-        deleted_count: 0,
-        days_kept: daysToKeep,
-      };
-    }
-
-    const BATCH_SIZE = 5000;
-    const archivedAt = new Date().toISOString();
-    let totalCount = 0;
-
-    // Process in batches: always fetch from the top since we delete as we go
-    while (true) {
-      const { data: batch, error: selectError } = await supabase
-        .from('bets')
-        .select('*')
-        .lt('date', cutoffDate)
-        .limit(BATCH_SIZE);
-
-      if (selectError) {
-        const errorMsg =
-          typeof selectError.message === 'string'
-            ? selectError.message
-            : JSON.stringify(selectError);
-        throw new Error(`Failed to select old bets: ${errorMsg}`);
-      }
-
-      if (!batch || batch.length === 0) break;
-
-      const ids = batch.map((b) => b.bet_id);
-
-      const { error: insertError } = await supabase.from('bets_archive').upsert(
-        batch.map((bet) => ({ ...bet, archived_at: archivedAt })),
-        { onConflict: 'bet_id', ignoreDuplicates: true }
-      );
-
-      if (insertError) {
-        const errorMsg =
-          typeof insertError.message === 'string'
-            ? insertError.message
-            : JSON.stringify(insertError);
-        throw new Error(`Failed to insert bets into archive: ${errorMsg}`);
-      }
-
-      const { error: deleteError } = await supabase.from('bets').delete().in('bet_id', ids);
-
-      if (deleteError) {
-        const errorMsg =
-          typeof deleteError.message === 'string'
-            ? deleteError.message
-            : JSON.stringify(deleteError);
-        throw new Error(`Failed to delete archived bets: ${errorMsg}`);
-      }
-
-      totalCount += batch.length;
-
-      if (batch.length < BATCH_SIZE) break;
-    }
-
-    return {
-      success: true,
-      message: totalCount === 0 ? 'No bets to archive' : 'Bets archived successfully',
-      cutoff_date: cutoffDate,
-      archived_count: totalCount,
-      deleted_count: totalCount,
-      days_kept: daysToKeep,
-    };
-  }
-
-  /**
-   * Manual implementation of archiving tickets (fallback)
-   * Processes in batches to avoid statement timeouts on large tables.
-   */
-  private async archiveOldTicketsManual(daysToKeep: number): Promise<IArchiveResult> {
-    const cutoffDate = await this.activityDaysRepo.getCutoffDate(daysToKeep);
-
-    if (!cutoffDate) {
-      return {
-        success: true,
-        message: 'Not enough active days to archive',
-        cutoff_date: null,
-        archived_count: 0,
-        deleted_count: 0,
-        days_kept: daysToKeep,
-      };
-    }
-
-    const BATCH_SIZE = 5000;
-    const archivedAt = new Date().toISOString();
-    let totalCount = 0;
-
-    while (true) {
-      const { data: batch, error: selectError } = await supabase
-        .from('tickets')
-        .select('*')
-        .lt('date', cutoffDate)
-        .limit(BATCH_SIZE);
-
-      if (selectError) {
-        const errorMsg =
-          typeof selectError.message === 'string'
-            ? selectError.message
-            : JSON.stringify(selectError);
-        throw new Error(`Failed to select old tickets: ${errorMsg}`);
-      }
-
-      if (!batch || batch.length === 0) break;
-
-      const ids = batch.map((t) => t.ticket_id);
-
-      const { error: insertError } = await supabase.from('tickets_archive').upsert(
-        batch.map((ticket) => ({ ...ticket, archived_at: archivedAt })),
-        { onConflict: 'ticket_id', ignoreDuplicates: true }
-      );
-
-      if (insertError) {
-        const errorMsg =
-          typeof insertError.message === 'string'
-            ? insertError.message
-            : JSON.stringify(insertError);
-        throw new Error(`Failed to insert tickets into archive: ${errorMsg}`);
-      }
-
-      const { error: deleteError } = await supabase.from('tickets').delete().in('ticket_id', ids);
-
-      if (deleteError) {
-        const errorMsg =
-          typeof deleteError.message === 'string'
-            ? deleteError.message
-            : JSON.stringify(deleteError);
-        throw new Error(`Failed to delete archived tickets: ${errorMsg}`);
-      }
-
-      totalCount += batch.length;
-
-      if (batch.length < BATCH_SIZE) break;
-    }
-
-    return {
-      success: true,
-      message: totalCount === 0 ? 'No tickets to archive' : 'Tickets archived successfully',
-      cutoff_date: cutoffDate,
-      archived_count: totalCount,
-      deleted_count: totalCount,
-      days_kept: daysToKeep,
-    };
-  }
-
-  /**
-   * Manual implementation of archiving both bets and tickets
-   */
-  private async archiveOldDataManual(daysToKeep: number): Promise<{
-    success: boolean;
-    bets: IArchiveResult;
-    tickets: IArchiveResult;
-    execution_time_ms?: number;
-  }> {
-    const startTime = Date.now();
-
-    const betsResult = await this.archiveOldBetsManual(daysToKeep);
-    const ticketsResult = await this.archiveOldTicketsManual(daysToKeep);
-
-    const executionTime = Date.now() - startTime;
-
-    return {
-      success: true,
-      bets: betsResult,
-      tickets: ticketsResult,
-      execution_time_ms: executionTime,
-    };
-  }
-
-  /**
-   * Manual implementation of getting archive stats
-   */
   private async getArchiveStatsManual(): Promise<IArchiveStats> {
-    // Count main tables (ALL rows, including deleted)
     const { count: betsMainCount } = await supabase
       .from('bets')
       .select('*', { count: 'exact', head: true });
@@ -324,7 +151,6 @@ export class ArchiveService {
       .from('tickets')
       .select('*', { count: 'exact', head: true });
 
-    // Count archive tables
     const { count: betsArchiveCount } = await supabase
       .from('bets_archive')
       .select('*', { count: 'exact', head: true });
@@ -333,17 +159,11 @@ export class ArchiveService {
       .from('tickets_archive')
       .select('*', { count: 'exact', head: true });
 
-    // Get activity info
     const activeDays = await this.activityDaysRepo.getActiveDaysOnly();
-
     const lastActiveDay = activeDays.length > 0 ? activeDays[0].date : null;
 
-    // Calculate compression ratios
     const betsTotal = (betsMainCount || 0) + (betsArchiveCount || 0);
     const ticketsTotal = (ticketsMainCount || 0) + (ticketsArchiveCount || 0);
-
-    const betsRatio = betsTotal > 0 ? ((betsArchiveCount || 0) / betsTotal) * 100 : 0;
-    const ticketsRatio = ticketsTotal > 0 ? ((ticketsArchiveCount || 0) / ticketsTotal) * 100 : 0;
 
     return {
       main_tables: {
@@ -359,8 +179,11 @@ export class ArchiveService {
         last_active_date: lastActiveDay,
       },
       compression_ratio: {
-        bets: Math.round(betsRatio * 100) / 100,
-        tickets: Math.round(ticketsRatio * 100) / 100,
+        bets: betsTotal > 0 ? Math.round(((betsArchiveCount || 0) / betsTotal) * 10000) / 100 : 0,
+        tickets:
+          ticketsTotal > 0
+            ? Math.round(((ticketsArchiveCount || 0) / ticketsTotal) * 10000) / 100
+            : 0,
       },
     };
   }

--- a/api/src/cron/service/cron.service.ts
+++ b/api/src/cron/service/cron.service.ts
@@ -102,17 +102,20 @@ export class CronService {
 
       // Step 7: Log results
       const executionTime = Date.now() - startTime;
+      const totalBets = result.days.reduce((sum, d) => sum + d.bets_archived, 0);
+      const totalTickets = result.days.reduce((sum, d) => sum + d.tickets_archived, 0);
+
       console.log('\n========================================');
       console.log('[CronService] Archive job completed successfully');
       console.log('========================================');
-      console.log('\nBETS:');
-      console.log(`  - Archived: ${result.bets.archived_count}`);
-      console.log(`  - Deleted from main: ${result.bets.deleted_count}`);
-      console.log(`  - Cutoff date: ${result.bets.cutoff_date}`);
-      console.log('\nTICKETS:');
-      console.log(`  - Archived: ${result.tickets.archived_count}`);
-      console.log(`  - Deleted from main: ${result.tickets.deleted_count}`);
-      console.log(`  - Cutoff date: ${result.tickets.cutoff_date}`);
+      console.log(`\nDays archived: ${result.days_succeeded} / ${result.days_attempted}`);
+      console.log(`Cutoff date:   ${result.cutoff_date}`);
+      console.log(`Total bets:    ${totalBets}`);
+      console.log(`Total tickets: ${totalTickets}`);
+      console.log('\nPer-day breakdown:');
+      for (const day of result.days) {
+        console.log(`  ${day.date}: ${day.bets_archived} bets, ${day.tickets_archived} tickets`);
+      }
       console.log('\nSTATS AFTER:');
       console.log(`  - Main bets: ${statsAfter.main_tables.bets_count}`);
       console.log(`  - Main tickets: ${statsAfter.main_tables.tickets_count}`);

--- a/api/supabase/migrations/20260415080624_archive_by_date.sql
+++ b/api/supabase/migrations/20260415080624_archive_by_date.sql
@@ -1,0 +1,119 @@
+-- Refactor archive to process one day at a time for timeout resilience.
+-- Each RPC call is scoped to a single date, so no single call can exceed
+-- the statement timeout regardless of total data volume.
+-- Replaces archive_old_bets, archive_old_tickets, archive_old_data.
+
+DROP FUNCTION IF EXISTS archive_old_bets(INTEGER);
+DROP FUNCTION IF EXISTS archive_old_tickets(INTEGER);
+DROP FUNCTION IF EXISTS archive_old_data(INTEGER);
+
+-- Keep tickets_archive in sync with tickets (client_request_id was added in 20260414090510)
+ALTER TABLE tickets_archive ADD COLUMN IF NOT EXISTS client_request_id UUID NULL;
+
+-- Returns all distinct dates that have bets or tickets older than the cutoff,
+-- sorted oldest first so the TypeScript loop archives in chronological order.
+CREATE OR REPLACE FUNCTION get_dates_to_archive(p_cutoff_date DATE)
+RETURNS DATE[]
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT date
+    FROM (
+      SELECT date FROM bets    WHERE date < p_cutoff_date
+      UNION
+      SELECT date FROM tickets WHERE date < p_cutoff_date
+    ) combined
+    ORDER BY date ASC
+  );
+$$;
+
+-- Archives all bets and tickets for a single date in one transaction.
+-- Bets are moved first because they hold the FK reference to tickets.
+-- Processes in batches of 5000 to stay well within per-statement timeouts
+-- (a single day has orders of magnitude fewer rows than the full table).
+CREATE OR REPLACE FUNCTION archive_data_by_date(p_date DATE)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_bets_archived     INTEGER := 0;
+  v_tickets_archived  INTEGER := 0;
+  v_batch_size        INTEGER := 5000;
+  v_batch_count       INTEGER;
+BEGIN
+  -- 1. Archive bets (must come before tickets due to FK bets.ticket_id → tickets.ticket_id)
+  --
+  -- INSERT target lists columns in the same order as the `bets` table, with
+  -- archived_at appended at the end. This lets the SELECT side stay as
+  -- `b.*, NOW()` — when a new column is added to bets/bets_archive, only the
+  -- target list below needs updating (not the SELECT).
+  --
+  -- Current bets column order (prod):
+  --   bet_id, bet_type, ticket_id, user_id, number, amount, place, "with",
+  --   position, date, winner, paid, lottery_id, schedule_id, created_at,
+  --   edited_at, deleted_at, prize, ticket_number, cashier_name, hits,
+  --   bet_order, organization_id
+  LOOP
+    WITH to_archive AS (
+      SELECT bet_id FROM bets WHERE date = p_date LIMIT v_batch_size
+    ),
+    inserted AS (
+      INSERT INTO bets_archive (
+        bet_id, bet_type, ticket_id, user_id, number, amount, place, "with",
+        position, date, winner, paid, lottery_id, schedule_id, created_at,
+        edited_at, deleted_at, prize, ticket_number, cashier_name, hits,
+        bet_order, organization_id,
+        archived_at
+      )
+      SELECT b.*, NOW()
+      FROM bets b
+      WHERE b.bet_id IN (SELECT bet_id FROM to_archive)
+      ON CONFLICT (bet_id) DO NOTHING
+    )
+    DELETE FROM bets WHERE bet_id IN (SELECT bet_id FROM to_archive);
+
+    GET DIAGNOSTICS v_batch_count = ROW_COUNT;
+    v_bets_archived := v_bets_archived + v_batch_count;
+    EXIT WHEN v_batch_count = 0;
+  END LOOP;
+
+  -- 2. Archive tickets (bets referencing them are already gone)
+  --
+  -- Same pattern: target lists tickets columns in tickets order, archived_at last.
+  --
+  -- Current tickets column order (prod + dev):
+  --   ticket_id, user_id, user_name, ticket_number, date, paid, winner, total,
+  --   created_at, deleted_at, deleted_by, total_prize, hits, organization_id,
+  --   client_request_id
+  LOOP
+    WITH to_archive AS (
+      SELECT ticket_id FROM tickets WHERE date = p_date LIMIT v_batch_size
+    ),
+    inserted AS (
+      INSERT INTO tickets_archive (
+        ticket_id, user_id, user_name, ticket_number, date, paid, winner, total,
+        created_at, deleted_at, deleted_by, total_prize, hits, organization_id,
+        client_request_id,
+        archived_at
+      )
+      SELECT t.*, NOW()
+      FROM tickets t
+      WHERE t.ticket_id IN (SELECT ticket_id FROM to_archive)
+      ON CONFLICT (ticket_id) DO NOTHING
+    )
+    DELETE FROM tickets WHERE ticket_id IN (SELECT ticket_id FROM to_archive);
+
+    GET DIAGNOSTICS v_batch_count = ROW_COUNT;
+    v_tickets_archived := v_tickets_archived + v_batch_count;
+    EXIT WHEN v_batch_count = 0;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success',           true,
+    'date',              p_date,
+    'bets_archived',     v_bets_archived,
+    'tickets_archived',  v_tickets_archived
+  );
+END;
+$$;


### PR DESCRIPTION
Root cause: archive_old_data SP processed 1.2M+ rows in a single transaction causing statement_timeout. The TS fallback also failed because .delete().in() with 5000 UUIDs exceeded HTTP URL length limits.

New approach: TypeScript fetches distinct dates via get_dates_to_archive RPC, then calls archive_data_by_date(date) per day. Each call is scoped to one day so it never approaches the timeout. Loop breaks on first failure and reports which date failed.

Also adds client_request_id to tickets_archive to keep schema in sync with the tickets table.