### PR TITLE
feat(current-account): add print totals ticket for day and date range

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-16
+
+#### Totales por rango de fechas en Cuenta Corriente
+- **`api/src/current-account/repository/current-account.repository.ts`**: Nuevo método `getTotalsByDateRangeHandler(organization_id, date_from, date_to, user_ids?)` — query GROUP BY date sobre `current_accounts` dentro de un rango, con soporte de filtro por `user_ids` (grupos) y red de organizaciones
+- **`api/src/current-account/controller/current-account.controller.ts`**: Nuevo método `getTotalsByDateRangeHandler` que delega al repositorio
+- **`api/src/current-account/route/current-account.route.ts`**: Nuevo endpoint `GET /totals` con query params `date_from`, `date_to`, `group_id` (opcional). Auto-scope a grupo para ADMIN con grupo asignado. Acceso: todos excepto CASHIER
+
 ### Fixed - 2026-04-15
 
 #### Ticket lookup always returning NOT_FOUND

--- a/api/src/current-account/controller/current-account.controller.ts
+++ b/api/src/current-account/controller/current-account.controller.ts
@@ -250,6 +250,28 @@ export class CurrentAccountController {
   };
 
   /**
+   * Get totals grouped by date within a date range
+   */
+  getTotalsByDateRangeHandler = async (
+    organization_id: string,
+    date_from: string,
+    date_to: string,
+    user_ids?: string[]
+  ) => {
+    try {
+      return await this.repository.getTotalsByDateRangeHandler(
+        organization_id,
+        date_from,
+        date_to,
+        user_ids
+      );
+    } catch (error) {
+      console.error('getTotalsByDateRangeHandler error:', error);
+      throw error instanceof Error ? error : new Error('Unknown error');
+    }
+  };
+
+  /**
    * Get network summary (aggregated totals per organization)
    */
   getNetworkSummaryHandler = async (

--- a/api/src/current-account/repository/current-account.repository.ts
+++ b/api/src/current-account/repository/current-account.repository.ts
@@ -270,4 +270,62 @@ export class CurrentAccountRepository {
     if (error) throw error;
     return data || [];
   }
+
+  /**
+   * Get aggregated totals grouped by date within a date range (for print totals ticket)
+   */
+  async getTotalsByDateRangeHandler(
+    organization_id: string,
+    date_from: string,
+    date_to: string,
+    user_ids?: string[]
+  ): Promise<
+    {
+      date: string;
+      total_collections: number;
+      total_paid: number;
+      total_bills: number;
+      total_balance: number;
+    }[]
+  > {
+    const orgIds = await this.getOrganizationNetworkIds(organization_id);
+
+    let query = supabase
+      .from('current_accounts')
+      .select('date, collections, paid, bills, total')
+      .in('organization_id', orgIds)
+      .gte('date', dayjs(date_from).format('YYYY-MM-DD'))
+      .lte('date', dayjs(date_to).format('YYYY-MM-DD'))
+      .order('date', { ascending: true });
+
+    if (user_ids && user_ids.length > 0) {
+      query = query.in('user_id', user_ids);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const byDate: Record<
+      string,
+      { total_collections: number; total_paid: number; total_bills: number; total_balance: number }
+    > = {};
+    for (const row of data ?? []) {
+      if (!byDate[row.date]) {
+        byDate[row.date] = {
+          total_collections: 0,
+          total_paid: 0,
+          total_bills: 0,
+          total_balance: 0,
+        };
+      }
+      byDate[row.date].total_collections += Number(row.collections) || 0;
+      byDate[row.date].total_paid += Number(row.paid) || 0;
+      byDate[row.date].total_bills += Number(row.bills) || 0;
+      byDate[row.date].total_balance += Number(row.total) || 0;
+    }
+
+    return Object.entries(byDate)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, totals]) => ({ date, ...totals }));
+  }
 }

--- a/api/src/current-account/route/current-account.route.ts
+++ b/api/src/current-account/route/current-account.route.ts
@@ -40,6 +40,7 @@ export class CurrentAccountRouter {
 
   private setupRoutes() {
     this.router.get('/network/summary', this.getNetworkSummaryHandler);
+    this.router.get('/totals', this.getTotalsByDateRangeHandler);
     this.router.get('/:id', this.getCurrentAccountHandler);
     this.router.get('/', this.getAllCurrentAccountHandler);
     this.router.post('/calculate', this.calculateCurrentAccountHandler);
@@ -609,6 +610,65 @@ export class CurrentAccountRouter {
         res.status(500).json(response);
         return;
       }
+    }
+  };
+
+  private getTotalsByDateRangeHandler: RequestHandler = async (req: Request, res: Response) => {
+    const { user } = req;
+    const { date_from, date_to, group_id } = req.query;
+
+    if (!user?.user) {
+      res
+        .status(400)
+        .json({ error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST } });
+      return;
+    }
+
+    if (user.user.user_type === USER_TYPE.CASHIER) {
+      res.status(403).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message: 'Access denied' } });
+      return;
+    }
+
+    if (!date_from || !date_to || typeof date_from !== 'string' || typeof date_to !== 'string') {
+      res
+        .status(400)
+        .json({
+          error: {
+            error: ERROR_TYPE.BAD_REQUEST,
+            message: 'Query params "date_from" and "date_to" (YYYY-MM-DD) are required',
+          },
+        });
+      return;
+    }
+
+    try {
+      let user_ids: string[] | undefined;
+
+      if (
+        user.user.user_type === USER_TYPE.ADMIN &&
+        user.user.group_id &&
+        user.user.group_id !== req.organization_id
+      ) {
+        user_ids = await this.userRepository.getUserIdsByGroupId(
+          user.user.group_id,
+          req.organization_id!
+        );
+      } else if (typeof group_id === 'string') {
+        user_ids = await this.userRepository.getUserIdsByGroupId(group_id, req.organization_id!);
+      }
+
+      const totals = await this.controller.getTotalsByDateRangeHandler(
+        req.organization_id!,
+        date_from,
+        date_to,
+        user_ids
+      );
+
+      res.status(200).json({ data: { totals } });
+    } catch (error) {
+      console.error(error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message } });
     }
   };
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-16
+
+#### Imprimir Totales — Cuenta Corriente
+- **`web/routes/routes.ts`**: Agrega ruta `totals` en `current_account` → `/api/private/current_account/totals`
+- **`web/src/hooks/fetchs/current-account/useGetCurrentAccountTotals.ts`**: Nuevo hook `useGetCurrentAccountTotals(date_from, date_to, group_id?)` y función `fetchCurrentAccountTotals` para obtener totales agrupados por día en un rango de fechas
+- **`web/src/functions/printTotalsTicket.ts`**: Dos funciones de impresión en formato ticket 80mm portrait:
+  - `printDailyTotalsTicket`: ticket diario con secciones "Me Pagó" / "Le Pagó", gastos manuales y saldo del día
+  - `printRangeTotalsTicket`: ticket de rango con totales por día, suma total y porcentaje configurable para capitalista
+- **`web/src/components/modals/PrintTotalsModal.tsx`**: Modal con opciones de impresión — modo día/rango, filtro por grupo, carga dinámica de gastos (nombre + monto) en modo día, y porcentaje editable en modo rango
+- **`web/src/features/current-account/index.tsx`**: Agrega botón "Imprimir Totales" que abre `PrintTotalsModal`, pre-poblado con fecha y grupo activos de la tabla
+
 ### Added - 2026-04-14
 
 #### Ticket Idempotency

--- a/web/routes/routes.ts
+++ b/web/routes/routes.ts
@@ -55,6 +55,7 @@ export const BACKEND_ROUTES = {
     bulk: `${PRIVATE}/current_account/bulk`,
     calculate: `${PRIVATE}/current_account/calculate`,
     liquidate: `${PRIVATE}/current_account/liquidate`,
+    totals: `${PRIVATE}/current_account/totals`,
   },
   results: {
     base: `${PRIVATE}/results`,

--- a/web/src/components/modals/PrintTotalsModal.tsx
+++ b/web/src/components/modals/PrintTotalsModal.tsx
@@ -1,0 +1,281 @@
+import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+import toast from 'react-hot-toast';
+import { PlusIcon, XIcon } from 'lucide-react';
+import Modal from './custom-modal';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SelectDayToSearch } from '@/components/button/SelectDayToSearch';
+import { useAuth } from '@/contexts/AuthContext';
+import { useGroups } from '@/hooks/fetchs/organization/useGroups';
+import { fetchCurrentAccount } from '@/hooks/fetchs/current-account/useGetCurrentAccount';
+import { fetchCurrentAccountTotals } from '@/hooks/fetchs/current-account/useGetCurrentAccountTotals';
+import { printDailyTotalsTicket, printRangeTotalsTicket } from '@/functions/printTotalsTicket';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import { BACKEND_ROUTES } from '../../../routes/routes';
+
+interface ExpenseItem {
+  nombre: string;
+  monto: number;
+}
+
+interface PrintTotalsModalProps {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  initialDate?: string | null;
+  initialGroupId?: string | null;
+}
+
+const PrintTotalsModal = ({
+  isOpen,
+  onClose,
+  initialDate,
+  initialGroupId,
+}: PrintTotalsModalProps) => {
+  const { organizationId, role } = useAuth();
+  const { data: groups } = useGroups(organizationId, role);
+
+  const [mode, setMode] = useState<'day' | 'range'>('day');
+  const [date, setDate] = useState<string>(initialDate ?? dayjs().format('YYYY-MM-DD'));
+  const [dateFrom, setDateFrom] = useState<string>(
+    dayjs().startOf('week').format('YYYY-MM-DD')
+  );
+  const [dateTo, setDateTo] = useState<string>(dayjs().format('YYYY-MM-DD'));
+  const [groupId, setGroupId] = useState<string>(initialGroupId ?? '');
+  const [percentage, setPercentage] = useState<number>(50);
+  const [expenses, setExpenses] = useState<ExpenseItem[]>([]);
+  const [printing, setPrinting] = useState(false);
+  const [orgName, setOrgName] = useState<string>('');
+
+  useEffect(() => {
+    if (!isOpen || !organizationId) return;
+    fetchWithAuth(BACKEND_ROUTES.organization.id(organizationId))
+      .then((r) => r.json())
+      .then((json) => setOrgName(json?.data?.organization?.name ?? ''))
+      .catch(() => setOrgName(''));
+  }, [isOpen, organizationId]);
+
+  const selectedGroup = groups?.find((g) => g.organization_id === groupId);
+
+  const addExpense = () =>
+    setExpenses((prev) => [...prev, { nombre: '', monto: 0 }]);
+
+  const removeExpense = (idx: number) =>
+    setExpenses((prev) => prev.filter((_, i) => i !== idx));
+
+  const updateExpense = (idx: number, field: keyof ExpenseItem, value: string | number) =>
+    setExpenses((prev) =>
+      prev.map((e, i) => (i === idx ? { ...e, [field]: value } : e))
+    );
+
+  const totalExpenses = expenses.reduce((s, e) => s + (Number(e.monto) || 0), 0);
+
+  const handlePrint = async () => {
+    try {
+      setPrinting(true);
+
+      if (mode === 'day') {
+        const data = await fetchCurrentAccount(date, groupId || null);
+        if (!data.length) {
+          toast.error('Sin datos para esa fecha.');
+          return;
+        }
+        await printDailyTotalsTicket({
+          data,
+          date,
+          orgName,
+          groupName: selectedGroup?.name,
+          expenses: expenses.filter((e) => e.nombre && e.monto > 0),
+        });
+        toast.success('Ticket generado.');
+      } else {
+        const dailyTotals = await fetchCurrentAccountTotals(
+          dateFrom,
+          dateTo,
+          groupId || null
+        );
+        if (!dailyTotals.length) {
+          toast.error('Sin datos para ese rango.');
+          return;
+        }
+        await printRangeTotalsTicket({
+          dailyTotals,
+          date_from: dateFrom,
+          date_to: dateTo,
+          percentage,
+          orgName,
+          groupName: selectedGroup?.name,
+        });
+        toast.success('Ticket generado.');
+      }
+
+      onClose();
+    } catch {
+      toast.error('Error al generar el ticket.');
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Imprimir Totales" className="max-w-md">
+      <div className="space-y-4">
+        {/* Modo */}
+        <div className="space-y-2">
+          <Label>Tipo de reporte</Label>
+          <RadioGroup
+            value={mode}
+            onValueChange={(v) => setMode(v as 'day' | 'range')}
+            className="flex gap-4"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="day" id="mode-day" />
+              <Label htmlFor="mode-day" className="cursor-pointer">
+                Día
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="range" id="mode-range" />
+              <Label htmlFor="mode-range" className="cursor-pointer">
+                Rango de fechas
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {/* Grupo */}
+        {groups && groups.length > 0 && (
+          <div className="space-y-1">
+            <Label>Grupo</Label>
+            <Select value={groupId} onValueChange={setGroupId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todos los grupos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Todos los grupos</SelectItem>
+                {groups.map((g) => (
+                  <SelectItem key={g.organization_id} value={g.organization_id}>
+                    {g.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {/* Fecha (modo día) */}
+        {mode === 'day' && (
+          <>
+            <div className="space-y-1">
+              <Label>Fecha</Label>
+              <SelectDayToSearch
+                selectedDay={date}
+                onDayChange={(d) => d && setDate(d)}
+                className="w-full"
+              />
+            </div>
+
+            {/* Gastos */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label>Gastos</Label>
+                <Button type="button" variant="outline" size="sm" onClick={addExpense}>
+                  <PlusIcon className="h-3 w-3 mr-1" />
+                  Agregar
+                </Button>
+              </div>
+
+              {expenses.map((exp, idx) => (
+                <div key={idx} className="flex items-center gap-2">
+                  <Input
+                    placeholder="Nombre del gasto"
+                    value={exp.nombre}
+                    onChange={(e) => updateExpense(idx, 'nombre', e.target.value)}
+                    className="flex-1"
+                  />
+                  <Input
+                    type="number"
+                    placeholder="Monto"
+                    value={exp.monto || ''}
+                    onChange={(e) => updateExpense(idx, 'monto', Number(e.target.value))}
+                    className="w-28"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeExpense(idx)}
+                  >
+                    <XIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+
+              {expenses.length > 0 && (
+                <div className="text-sm text-right opacity-70">
+                  Total gastos:{' '}
+                  {new Intl.NumberFormat('es-AR', { minimumFractionDigits: 0 }).format(
+                    totalExpenses
+                  )}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Rango de fechas */}
+        {mode === 'range' && (
+          <>
+            <div className="space-y-1">
+              <Label>Desde</Label>
+              <SelectDayToSearch
+                selectedDay={dateFrom}
+                onDayChange={(d) => d && setDateFrom(d)}
+                className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Hasta</Label>
+              <SelectDayToSearch
+                selectedDay={dateTo}
+                onDayChange={(d) => d && setDateTo(d)}
+                className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Porcentaje capitalista (%)</Label>
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                value={percentage}
+                onChange={(e) => setPercentage(Number(e.target.value))}
+                className="w-28"
+              />
+            </div>
+          </>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={printing}>
+            Cancelar
+          </Button>
+          <Button onClick={handlePrint} disabled={printing}>
+            {printing ? 'Generando...' : 'Imprimir'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PrintTotalsModal;

--- a/web/src/features/current-account/index.tsx
+++ b/web/src/features/current-account/index.tsx
@@ -26,11 +26,13 @@ import { PageWrapper } from '@/components/wrapper/PageWrapper';
 const CurrentAccountContent = () => {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState<boolean>(false);
+  const [openPrintTotals, setOpenPrintTotals] = useState<boolean>(false);
   const { role } = useAuth();
   const [searchParams] = useSearchParams();
   const { mutate: calculateCurrentAccount } = useCalculateCurrentAccount();
   const [printing, setPrinting] = useState(false);
   const date = searchParams.get('date'); // puede ser null: backend devuelve la última
+  const group_id = searchParams.get('group_id');
 
   const handleUpdateCurrentAccount = () => {
     calculateCurrentAccount(searchParams.get('date'), {
@@ -132,6 +134,9 @@ const CurrentAccountContent = () => {
             <Button variant="outline" onClick={handlePrintLiquidationCashier} disabled={printing}>
               Exportar Liquidación
             </Button>
+            <Button variant={'outline'} onClick={() => setOpenPrintTotals(true)} disabled={printing}>
+              Imprimir Totales
+            </Button>
             <Button variant={'outline'} onClick={handleUpdateCurrentAccount}>
               Actualizar
             </Button>
@@ -147,6 +152,14 @@ const CurrentAccountContent = () => {
       <Suspense>
         <GenerateLiquitationModal isOpen={open} onClose={() => setOpen(false)} />
       </Suspense>
+      <Suspense>
+        <PrintTotalsModal
+          isOpen={openPrintTotals}
+          onClose={() => setOpenPrintTotals(false)}
+          initialDate={date}
+          initialGroupId={group_id}
+        />
+      </Suspense>
     </PageWrapper>
   );
 };
@@ -155,4 +168,8 @@ export default CurrentAccountContent;
 
 const GenerateLiquitationModal = React.lazy(
   () => import('../../components/modals/GenerateLiquitationModal')
+);
+
+const PrintTotalsModal = React.lazy(
+  () => import('../../components/modals/PrintTotalsModal')
 );

--- a/web/src/functions/printTotalsTicket.ts
+++ b/web/src/functions/printTotalsTicket.ts
@@ -1,0 +1,226 @@
+import dayjs from 'dayjs';
+import weekOfYear from 'dayjs/plugin/weekOfYear';
+import { ICurrentAccountEntityFront } from '@helper/types/current_account.type';
+import { DailyTotalEntry } from '@/hooks/fetchs/current-account/useGetCurrentAccountTotals';
+
+dayjs.extend(weekOfYear);
+
+const TICKET_WIDTH = 72; // mm — ancho del ticket (80mm - márgenes)
+const MARGIN = { left: 4, right: 4 };
+const FONT_SIZE = 8;
+const LINE_H = 4.5;
+
+async function getPDFDeps() {
+  const { default: jsPDF } = await import('jspdf');
+  return { jsPDF };
+}
+
+const money = (n: number) =>
+  new Intl.NumberFormat('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(
+    Number.isFinite(n) ? n : 0
+  );
+
+/** Pad string derecha con espacios hasta targetLen, luego agrega valor alineado a la derecha */
+function lineWithAmount(doc: any, label: string, amount: string, y: number) {
+  doc.text(label, MARGIN.left, y);
+  doc.text(amount, TICKET_WIDTH + MARGIN.left - MARGIN.right, y, { align: 'right' });
+}
+
+function drawDivider(doc: any, y: number) {
+  doc.setLineDashPattern([1, 1], 0);
+  doc.line(MARGIN.left, y, TICKET_WIDTH + MARGIN.left - MARGIN.right, y);
+  doc.setLineDashPattern([], 0);
+}
+
+export async function printDailyTotalsTicket(params: {
+  data: ICurrentAccountEntityFront[];
+  date: string;
+  orgName: string;
+  groupName?: string;
+  expenses: { nombre: string; monto: number }[];
+}) {
+  const { data, date, orgName, groupName, expenses } = params;
+  const { jsPDF } = await getPDFDeps();
+
+  const mePago = data.filter((a) => (a.collections ?? 0) > 0);
+  const lePago = data.filter((a) => (a.paid ?? 0) > 0);
+  const totalCollections = mePago.reduce((s, a) => s + (a.collections ?? 0), 0);
+  const totalPaid = lePago.reduce((s, a) => s + (a.paid ?? 0), 0);
+  const totalExpenses = expenses.reduce((s, e) => s + (e.monto ?? 0), 0);
+  const saldoDia = totalCollections - totalPaid - totalExpenses;
+
+  const weekNum = dayjs(date).week();
+  const dateStr = dayjs(date).format('DD/MM/YYYY');
+
+  // Calcular alto del documento dinámicamente
+  const headerLines = 5;
+  const mePagoLines = mePago.length + 2; // items + encabezado + subtotal
+  const lePagoLines = lePago.length + 2;
+  const expenseLines = expenses.length > 0 ? expenses.length + 2 : 2;
+  const footerLines = 2;
+  const totalLines = headerLines + mePagoLines + lePagoLines + expenseLines + footerLines + 6; // 6 = separadores/espacios
+  const docHeight = Math.max(100, totalLines * LINE_H + 20);
+
+  const doc = new jsPDF({
+    orientation: 'portrait',
+    unit: 'mm',
+    format: [80, docHeight],
+  });
+
+  doc.setFont('Courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+
+  let y = 8;
+
+  // Encabezado
+  doc.setFontSize(FONT_SIZE + 1);
+  doc.setFont('Courier', 'bold');
+  doc.text(`Semana Nro. ${weekNum}`, 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  doc.text(orgName.toUpperCase(), 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  if (groupName) {
+    doc.text(groupName.toUpperCase(), 80 / 2, y, { align: 'center' });
+    y += LINE_H;
+  }
+  doc.setFont('Courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+  doc.text(`FECHA: ${dateStr}`, 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  doc.text('ENTRADA Y SALIDA DEL DIA', 80 / 2, y, { align: 'center' });
+  y += LINE_H + 2;
+
+  drawDivider(doc, y);
+  y += 3;
+
+  // Sección "Me Pagó"
+  if (mePago.length > 0) {
+    for (const acc of mePago) {
+      lineWithAmount(doc, `${acc.user_number} Me Pagó`, money(acc.collections ?? 0), y);
+      y += LINE_H;
+    }
+    y += 1;
+    doc.setFont('Courier', 'bold');
+    lineWithAmount(doc, 'Sub-I. Entr.:', money(totalCollections), y);
+    doc.setFont('Courier', 'normal');
+    y += LINE_H + 1;
+  }
+
+  drawDivider(doc, y);
+  y += 3;
+
+  // Sección "Le Pagó"
+  if (lePago.length > 0) {
+    for (const acc of lePago) {
+      lineWithAmount(doc, `${acc.user_number} Le Pagó`, money(acc.paid ?? 0), y);
+      y += LINE_H;
+    }
+    y += 1;
+    doc.setFont('Courier', 'bold');
+    lineWithAmount(doc, 'Sub-I. Sal.:', money(totalPaid), y);
+    doc.setFont('Courier', 'normal');
+    y += LINE_H + 1;
+  }
+
+  drawDivider(doc, y);
+  y += 3;
+
+  // Gastos
+  if (expenses.length > 0) {
+    for (const exp of expenses) {
+      lineWithAmount(doc, exp.nombre, money(exp.monto), y);
+      y += LINE_H;
+    }
+    y += 1;
+  }
+  doc.setFont('Courier', 'bold');
+  lineWithAmount(doc, 'GASTOS:', money(totalExpenses), y);
+  doc.setFont('Courier', 'normal');
+  y += LINE_H + 1;
+
+  drawDivider(doc, y);
+  y += 3;
+
+  // Saldo del día
+  doc.setFontSize(FONT_SIZE + 1);
+  doc.setFont('Courier', 'bold');
+  lineWithAmount(doc, 'SALDO DEL DIA:', money(saldoDia), y);
+  doc.setFont('Courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+
+  doc.save(`Totales_${dateStr.replace(/\//g, '-')}.pdf`);
+}
+
+export async function printRangeTotalsTicket(params: {
+  dailyTotals: DailyTotalEntry[];
+  date_from: string;
+  date_to: string;
+  percentage: number;
+  orgName: string;
+  groupName?: string;
+}) {
+  const { dailyTotals, date_from, date_to, percentage, orgName, groupName } = params;
+  const { jsPDF } = await getPDFDeps();
+
+  const grandTotal = dailyTotals.reduce((s, d) => s + d.total_balance, 0);
+  const percentageAmount = (grandTotal * percentage) / 100;
+
+  const weekStart = dayjs(date_from).week();
+  const fromStr = dayjs(date_from).format('DD/MM/YYYY');
+  const toStr = dayjs(date_to).format('DD/MM/YYYY');
+
+  const totalLines = 6 + dailyTotals.length + 5 + (groupName ? 1 : 0);
+  const docHeight = Math.max(100, totalLines * LINE_H + 20);
+
+  const doc = new jsPDF({
+    orientation: 'portrait',
+    unit: 'mm',
+    format: [80, docHeight],
+  });
+
+  doc.setFont('Courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+
+  let y = 8;
+
+  // Encabezado
+  doc.setFontSize(FONT_SIZE + 1);
+  doc.setFont('Courier', 'bold');
+  doc.text(`Semana Nro. ${weekStart}`, 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  doc.text(orgName.toUpperCase(), 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  if (groupName) {
+    doc.text(groupName.toUpperCase(), 80 / 2, y, { align: 'center' });
+    y += LINE_H;
+  }
+  doc.setFont('Courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+  doc.text(`FECHA: ${fromStr} AL ${toStr}`, 80 / 2, y, { align: 'center' });
+  y += LINE_H;
+  doc.text('BALANCE DE ENTRADA-SALIDA', 80 / 2, y, { align: 'center' });
+  y += LINE_H + 2;
+
+  drawDivider(doc, y);
+  y += 3;
+
+  // Totales por día
+  for (const entry of dailyTotals) {
+    const dateLabel = dayjs(entry.date).format('DD/MM/YY');
+    lineWithAmount(doc, dateLabel, money(entry.total_balance), y);
+    y += LINE_H;
+  }
+
+  y += 1;
+  drawDivider(doc, y);
+  y += 3;
+
+  doc.setFont('Courier', 'bold');
+  lineWithAmount(doc, 'UN A LA FECHA:', money(grandTotal), y);
+  y += LINE_H + 2;
+
+  lineWithAmount(doc, `${percentage}%:`, money(percentageAmount), y);
+  doc.setFont('Courier', 'normal');
+
+  doc.save(`Totales_Rango_${fromStr.replace(/\//g, '-')}_${toStr.replace(/\//g, '-')}.pdf`);
+}

--- a/web/src/hooks/fetchs/current-account/useGetCurrentAccountTotals.ts
+++ b/web/src/hooks/fetchs/current-account/useGetCurrentAccountTotals.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { BACKEND_ROUTES } from '../../../../routes/routes.ts';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+
+export type DailyTotalEntry = {
+  date: string;
+  total_collections: number;
+  total_paid: number;
+  total_bills: number;
+  total_balance: number;
+};
+
+export const currentAccountTotalsKey = (date_from?: string | null, date_to?: string | null, group_id?: string | null) =>
+  ['getCurrentAccountTotals', date_from ?? '', date_to ?? '', group_id ?? ''] as const;
+
+export async function fetchCurrentAccountTotals(
+  date_from: string,
+  date_to: string,
+  group_id?: string | null
+): Promise<DailyTotalEntry[]> {
+  const params = new URLSearchParams({ date_from, date_to });
+  if (group_id) params.set('group_id', group_id);
+
+  const res = await fetchWithAuth(`${BACKEND_ROUTES.current_account.totals}?${params.toString()}`, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) throw new Error('Error fetching totals');
+
+  const json = await res.json();
+  return json?.data?.totals ?? [];
+}
+
+export function useGetCurrentAccountTotals(
+  date_from?: string | null,
+  date_to?: string | null,
+  group_id?: string | null
+) {
+  return useQuery<DailyTotalEntry[]>({
+    queryKey: currentAccountTotalsKey(date_from, date_to, group_id),
+    queryFn: () => fetchCurrentAccountTotals(date_from!, date_to!, group_id),
+    enabled: !!date_from && !!date_to,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
Agents needed a receipt-format summary (80mm portrait) showing Me Pagó / Le Pagó per pasador, manual expenses, and daily balance. Range mode aggregates daily totals with a configurable % split for the capitalista.

- GET /totals endpoint groups current_accounts by date in range, supports group_id scoping and org network
- printDailyTotalsTicket and printRangeTotalsTicket use jsPDF in 80mm portrait (thermal receipt format)
- PrintTotalsModal lets user pick day vs range, add named expenses, select group, and set the split percentage (default 50%)
- Imprimir Totales button pre-populates active date and group from table search params