### PR TITLE
feat(org-expenses): persist daily org expenses for consistent range t…

### DIFF
--- a/api/src/current-account/repository/current-account.repository.ts
+++ b/api/src/current-account/repository/current-account.repository.ts
@@ -5,6 +5,7 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { ICurrentAccountEntityBack } from '@helper/types/current_account.type';
 import { globalCacheManager } from '../../cache/CacheManager';
+import { OrgExpenseRepository } from '../../org-expense/repository/org-expense.repository';
 
 const ORG_NETWORK_IDS_TTL = 10 * 60 * 1000; // 10 minutes
 
@@ -272,7 +273,8 @@ export class CurrentAccountRepository {
   }
 
   /**
-   * Get aggregated totals grouped by date within a date range (for print totals ticket)
+   * Get aggregated totals grouped by date within a date range (for print totals ticket).
+   * Includes org_expenses per day so net_balance is consistent with daily tickets.
    */
   async getTotalsByDateRangeHandler(
     organization_id: string,
@@ -286,6 +288,8 @@ export class CurrentAccountRepository {
       total_paid: number;
       total_bills: number;
       total_balance: number;
+      total_expenses: number;
+      net_balance: number;
     }[]
   > {
     const orgIds = await this.getOrganizationNetworkIds(organization_id);
@@ -302,8 +306,16 @@ export class CurrentAccountRepository {
       query = query.in('user_id', user_ids);
     }
 
-    const { data, error } = await query;
+    const [{ data, error }, expenseSums] = await Promise.all([
+      query,
+      new OrgExpenseRepository().getSumsByDateRange(organization_id, date_from, date_to),
+    ]);
     if (error) throw error;
+
+    const expenseByDate: Record<string, number> = {};
+    for (const e of expenseSums) {
+      expenseByDate[e.date] = e.total_expenses;
+    }
 
     const byDate: Record<
       string,
@@ -326,6 +338,14 @@ export class CurrentAccountRepository {
 
     return Object.entries(byDate)
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, totals]) => ({ date, ...totals }));
+      .map(([date, totals]) => {
+        const total_expenses = expenseByDate[date] ?? 0;
+        return {
+          date,
+          ...totals,
+          total_expenses,
+          net_balance: totals.total_balance - total_expenses,
+        };
+      });
   }
 }

--- a/api/src/org-expense/controller/org-expense.controller.ts
+++ b/api/src/org-expense/controller/org-expense.controller.ts
@@ -1,0 +1,34 @@
+import { IOrgExpense, OrgExpenseRepository } from '../repository/org-expense.repository';
+
+export class OrgExpenseController {
+  private repository = new OrgExpenseRepository();
+
+  getByOrgAndDate = async (organization_id: string, date: string): Promise<IOrgExpense[]> => {
+    try {
+      return await this.repository.getByOrgAndDate(organization_id, date);
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('Unknown error');
+    }
+  };
+
+  create = async (
+    organization_id: string,
+    date: string,
+    name: string,
+    amount: number
+  ): Promise<IOrgExpense> => {
+    try {
+      return await this.repository.create(organization_id, date, name, amount);
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('Unknown error');
+    }
+  };
+
+  delete = async (expense_id: string, organization_id: string): Promise<void> => {
+    try {
+      await this.repository.delete(expense_id, organization_id);
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('Unknown error');
+    }
+  };
+}

--- a/api/src/org-expense/repository/org-expense.repository.ts
+++ b/api/src/org-expense/repository/org-expense.repository.ts
@@ -1,0 +1,79 @@
+import { supabase } from '@database/db.connection';
+import dayjs from 'dayjs';
+
+export interface IOrgExpense {
+  expense_id: string;
+  organization_id: string;
+  date: string;
+  name: string;
+  amount: number;
+  created_at: string;
+  edited_at: string;
+}
+
+export class OrgExpenseRepository {
+  async getByOrgAndDate(organization_id: string, date: string): Promise<IOrgExpense[]> {
+    const { data, error } = await supabase
+      .from('org_expenses')
+      .select('*')
+      .eq('organization_id', organization_id)
+      .eq('date', dayjs(date).format('YYYY-MM-DD'))
+      .order('created_at', { ascending: true });
+
+    if (error) throw new Error(error.message);
+    return data ?? [];
+  }
+
+  async getSumsByDateRange(
+    organization_id: string,
+    date_from: string,
+    date_to: string
+  ): Promise<{ date: string; total_expenses: number }[]> {
+    const { data, error } = await supabase
+      .from('org_expenses')
+      .select('date, amount')
+      .eq('organization_id', organization_id)
+      .gte('date', dayjs(date_from).format('YYYY-MM-DD'))
+      .lte('date', dayjs(date_to).format('YYYY-MM-DD'));
+
+    if (error) throw new Error(error.message);
+
+    const byDate: Record<string, number> = {};
+    for (const row of data ?? []) {
+      byDate[row.date] = (byDate[row.date] ?? 0) + Number(row.amount);
+    }
+
+    return Object.entries(byDate).map(([date, total_expenses]) => ({ date, total_expenses }));
+  }
+
+  async create(
+    organization_id: string,
+    date: string,
+    name: string,
+    amount: number
+  ): Promise<IOrgExpense> {
+    const { data, error } = await supabase
+      .from('org_expenses')
+      .insert({
+        organization_id,
+        date: dayjs(date).format('YYYY-MM-DD'),
+        name,
+        amount,
+      })
+      .select()
+      .single();
+
+    if (error) throw new Error(error.message);
+    return data;
+  }
+
+  async delete(expense_id: string, organization_id: string): Promise<void> {
+    const { error } = await supabase
+      .from('org_expenses')
+      .delete()
+      .eq('expense_id', expense_id)
+      .eq('organization_id', organization_id);
+
+    if (error) throw new Error(error.message);
+  }
+}

--- a/api/src/org-expense/route/org-expense.route.ts
+++ b/api/src/org-expense/route/org-expense.route.ts
@@ -1,0 +1,101 @@
+import { Request, RequestHandler, Response, Router } from 'express';
+import { ERROR_MESSAGE, ERROR_TYPE } from '@helper/types/errors.type';
+import { USER_TYPE } from '@helper/types/user.type';
+import { OrgExpenseController } from '../controller/org-expense.controller';
+
+export class OrgExpenseRouter {
+  public router: Router;
+  private controller: OrgExpenseController;
+
+  constructor() {
+    this.router = Router();
+    this.controller = new OrgExpenseController();
+    this.setupRoutes();
+  }
+
+  private setupRoutes() {
+    this.router.get('/', this.getByDateHandler);
+    this.router.post('/', this.createHandler);
+    this.router.delete('/:id', this.deleteHandler);
+  }
+
+  private getByDateHandler: RequestHandler = async (req: Request, res: Response) => {
+    const { user } = req;
+    const { date } = req.query;
+
+    if (!user?.user || !date || typeof date !== 'string') {
+      res
+        .status(400)
+        .json({ error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST } });
+      return;
+    }
+
+    if (user.user.user_type === USER_TYPE.CASHIER) {
+      res.status(403).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message: 'Access denied' } });
+      return;
+    }
+
+    try {
+      const expenses = await this.controller.getByOrgAndDate(req.organization_id!, date);
+      res.status(200).json({ data: { expenses } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message } });
+    }
+  };
+
+  private createHandler: RequestHandler = async (req: Request, res: Response) => {
+    const { user } = req;
+    const { date, name, amount } = req.body;
+
+    if (!user?.user || !date || !name || amount === undefined) {
+      res
+        .status(400)
+        .json({ error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST } });
+      return;
+    }
+
+    if (user.user.user_type === USER_TYPE.CASHIER) {
+      res.status(403).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message: 'Access denied' } });
+      return;
+    }
+
+    try {
+      const expense = await this.controller.create(
+        req.organization_id!,
+        date,
+        name,
+        Number(amount)
+      );
+      res.status(201).json({ data: { expense } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message } });
+    }
+  };
+
+  private deleteHandler: RequestHandler = async (req: Request, res: Response) => {
+    const { user } = req;
+    const { id } = req.params;
+
+    if (!user?.user) {
+      res
+        .status(400)
+        .json({ error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST } });
+      return;
+    }
+
+    if (user.user.user_type === USER_TYPE.CASHIER) {
+      res.status(403).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message: 'Access denied' } });
+      return;
+    }
+
+    try {
+      await this.controller.delete(id, req.organization_id!);
+      res.status(200).json({ data: { ok: true } });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message } });
+    }
+  };
+}

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -12,6 +12,7 @@ import { ScheduleLotteryRouter } from './schedule-lottery/route/schedule-lottery
 import { SettingsLotteryRouter } from './settings/route/settings.route';
 import { OrganizationRouter } from './organization/route/organization.route';
 import archiveRouter from './archive/route/archive.route';
+import { OrgExpenseRouter } from './org-expense/route/org-expense.route';
 
 export const router = Router();
 export const publicRouter = Router();
@@ -35,6 +36,7 @@ router.use('/schedule_lottery', new ScheduleLotteryRouter().router);
 router.use('/settings', new SettingsLotteryRouter().router);
 router.use('/organization', new OrganizationRouter().router);
 router.use('/archive', archiveRouter);
+router.use('/org_expense', new OrgExpenseRouter().router);
 router.use('/test', (req, res) => {
   res.send('ok');
 });

--- a/api/supabase/migrations/20260416112439_add_org_expenses_table.sql
+++ b/api/supabase/migrations/20260416112439_add_org_expenses_table.sql
@@ -1,0 +1,20 @@
+-- Migration: add org_expenses table
+-- Purpose: Persist organization-level daily expenses so range-date totals
+--          remain consistent with daily ticket totals.
+
+CREATE TABLE org_expenses (
+  expense_id     UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID       NOT NULL,
+  date           DATE        NOT NULL,
+  name           TEXT        NOT NULL,
+  amount         NUMERIC(12, 2) NOT NULL DEFAULT 0,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  edited_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT fk_org_expenses_organization
+    FOREIGN KEY (organization_id)
+    REFERENCES organizations(organization_id)
+    ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_org_expenses_org_date ON org_expenses(organization_id, date);

--- a/web/routes/routes.ts
+++ b/web/routes/routes.ts
@@ -67,6 +67,10 @@ export const BACKEND_ROUTES = {
   settings: {
     storage: `${PRIVATE}/settings/storage`,
   },
+  org_expense: {
+    base: `${PRIVATE}/org_expense`,
+    id: (id: string) => `${PRIVATE}/org_expense/${id}`,
+  },
   organization: {
     base: `${PRIVATE}/organization`,
     id: (id: string) => `${PRIVATE}/organization/${id}`,

--- a/web/src/components/modals/PrintTotalsModal.tsx
+++ b/web/src/components/modals/PrintTotalsModal.tsx
@@ -20,13 +20,13 @@ import { useGroups } from '@/hooks/fetchs/organization/useGroups';
 import { fetchCurrentAccount } from '@/hooks/fetchs/current-account/useGetCurrentAccount';
 import { fetchCurrentAccountTotals } from '@/hooks/fetchs/current-account/useGetCurrentAccountTotals';
 import { printDailyTotalsTicket, printRangeTotalsTicket } from '@/functions/printTotalsTicket';
+import { useGetOrgExpenses, type OrgExpense } from '@/hooks/fetchs/org-expense/useGetOrgExpenses';
+import { useCreateOrgExpense } from '@/hooks/mutations/org-expense/useCreateOrgExpense';
+import { useDeleteOrgExpense } from '@/hooks/mutations/org-expense/useDeleteOrgExpense';
 import { fetchWithAuth } from '@/lib/fetchWithAuth';
 import { BACKEND_ROUTES } from '../../../routes/routes';
 
-interface ExpenseItem {
-  nombre: string;
-  monto: number;
-}
+const ALL_GROUPS = '__all__';
 
 interface PrintTotalsModalProps {
   isOpen: boolean;
@@ -46,16 +46,24 @@ const PrintTotalsModal = ({
 
   const [mode, setMode] = useState<'day' | 'range'>('day');
   const [date, setDate] = useState<string>(initialDate ?? dayjs().format('YYYY-MM-DD'));
-  const [dateFrom, setDateFrom] = useState<string>(
-    dayjs().startOf('week').format('YYYY-MM-DD')
-  );
+  const [dateFrom, setDateFrom] = useState<string>(dayjs().startOf('week').format('YYYY-MM-DD'));
   const [dateTo, setDateTo] = useState<string>(dayjs().format('YYYY-MM-DD'));
-  const ALL_GROUPS = '__all__';
   const [groupId, setGroupId] = useState<string>(initialGroupId || ALL_GROUPS);
   const [percentage, setPercentage] = useState<number>(50);
-  const [expenses, setExpenses] = useState<ExpenseItem[]>([]);
   const [printing, setPrinting] = useState(false);
   const [orgName, setOrgName] = useState<string>('');
+
+  // New expense form state (before saving)
+  const [newExpenseName, setNewExpenseName] = useState('');
+  const [newExpenseAmount, setNewExpenseAmount] = useState('');
+
+  const effectiveGroupId = groupId === ALL_GROUPS ? null : groupId;
+  const selectedGroup = groups?.find((g) => g.organization_id === groupId);
+
+  // Load existing expenses from DB for selected date
+  const { data: savedExpenses = [] } = useGetOrgExpenses(mode === 'day' ? date : null);
+  const { mutate: createExpense, isPending: creating } = useCreateOrgExpense();
+  const { mutate: deleteExpense } = useDeleteOrgExpense(date);
 
   useEffect(() => {
     if (!isOpen || !organizationId) return;
@@ -68,21 +76,32 @@ const PrintTotalsModal = ({
       .catch(() => setOrgName(''));
   }, [isOpen, organizationId]);
 
-  const effectiveGroupId = groupId === ALL_GROUPS ? null : groupId;
-  const selectedGroup = groups?.find((g) => g.organization_id === groupId);
-
-  const addExpense = () =>
-    setExpenses((prev) => [...prev, { nombre: '', monto: 0 }]);
-
-  const removeExpense = (idx: number) =>
-    setExpenses((prev) => prev.filter((_, i) => i !== idx));
-
-  const updateExpense = (idx: number, field: keyof ExpenseItem, value: string | number) =>
-    setExpenses((prev) =>
-      prev.map((e, i) => (i === idx ? { ...e, [field]: value } : e))
+  const handleAddExpense = () => {
+    const name = newExpenseName.trim();
+    const amount = Number(newExpenseAmount);
+    if (!name || !amount) {
+      toast.error('Ingresá nombre y monto.');
+      return;
+    }
+    createExpense(
+      { date, name, amount },
+      {
+        onSuccess: () => {
+          setNewExpenseName('');
+          setNewExpenseAmount('');
+        },
+        onError: () => toast.error('Error al guardar el gasto.'),
+      }
     );
+  };
 
-  const totalExpenses = expenses.reduce((s, e) => s + (Number(e.monto) || 0), 0);
+  const handleDeleteExpense = (expense: OrgExpense) => {
+    deleteExpense(expense.expense_id, {
+      onError: () => toast.error('Error al eliminar el gasto.'),
+    });
+  };
+
+  const totalExpenses = savedExpenses.reduce((s, e) => s + (e.amount ?? 0), 0);
 
   const handlePrint = async () => {
     try {
@@ -99,15 +118,11 @@ const PrintTotalsModal = ({
           date,
           orgName,
           groupName: selectedGroup?.name,
-          expenses: expenses.filter((e) => e.nombre && e.monto > 0),
+          expenses: savedExpenses.map((e) => ({ nombre: e.name, monto: e.amount })),
         });
         toast.success('Ticket generado.');
       } else {
-        const dailyTotals = await fetchCurrentAccountTotals(
-          dateFrom,
-          dateTo,
-          effectiveGroupId
-        );
+        const dailyTotals = await fetchCurrentAccountTotals(dateFrom, dateTo, effectiveGroupId);
         if (!dailyTotals.length) {
           toast.error('Sin datos para ese rango.');
           return;
@@ -177,7 +192,7 @@ const PrintTotalsModal = ({
           </div>
         )}
 
-        {/* Fecha (modo día) */}
+        {/* Modo día */}
         {mode === 'day' && (
           <>
             <div className="space-y-1">
@@ -189,43 +204,55 @@ const PrintTotalsModal = ({
               />
             </div>
 
-            {/* Gastos */}
+            {/* Gastos persistidos */}
             <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label>Gastos</Label>
-                <Button type="button" variant="outline" size="sm" onClick={addExpense}>
-                  <PlusIcon className="h-3 w-3 mr-1" />
-                  Agregar
-                </Button>
-              </div>
+              <Label>Gastos del día</Label>
 
-              {expenses.map((exp, idx) => (
-                <div key={idx} className="flex items-center gap-2">
-                  <Input
-                    placeholder="Nombre del gasto"
-                    value={exp.nombre}
-                    onChange={(e) => updateExpense(idx, 'nombre', e.target.value)}
-                    className="flex-1"
-                  />
-                  <Input
-                    type="number"
-                    placeholder="Monto"
-                    value={exp.monto || ''}
-                    onChange={(e) => updateExpense(idx, 'monto', Number(e.target.value))}
-                    className="w-28"
-                  />
+              {/* Lista de gastos guardados */}
+              {savedExpenses.map((exp) => (
+                <div key={exp.expense_id} className="flex items-center gap-2">
+                  <span className="flex-1 text-sm">{exp.name}</span>
+                  <span className="text-sm w-24 text-right">
+                    {new Intl.NumberFormat('es-AR', { minimumFractionDigits: 0 }).format(exp.amount)}
+                  </span>
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => removeExpense(idx)}
+                    onClick={() => handleDeleteExpense(exp)}
                   >
                     <XIcon className="h-4 w-4" />
                   </Button>
                 </div>
               ))}
 
-              {expenses.length > 0 && (
+              {/* Form para agregar nuevo gasto */}
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder="Nombre del gasto"
+                  value={newExpenseName}
+                  onChange={(e) => setNewExpenseName(e.target.value)}
+                  className="flex-1"
+                />
+                <Input
+                  type="number"
+                  placeholder="Monto"
+                  value={newExpenseAmount}
+                  onChange={(e) => setNewExpenseAmount(e.target.value)}
+                  className="w-28"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddExpense}
+                  disabled={creating}
+                >
+                  <PlusIcon className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {totalExpenses > 0 && (
                 <div className="text-sm text-right opacity-70">
                   Total gastos:{' '}
                   {new Intl.NumberFormat('es-AR', { minimumFractionDigits: 0 }).format(
@@ -237,7 +264,7 @@ const PrintTotalsModal = ({
           </>
         )}
 
-        {/* Rango de fechas */}
+        {/* Modo rango */}
         {mode === 'range' && (
           <>
             <div className="space-y-1">

--- a/web/src/functions/printTotalsTicket.ts
+++ b/web/src/functions/printTotalsTicket.ts
@@ -162,7 +162,7 @@ export async function printRangeTotalsTicket(params: {
   const { dailyTotals, date_from, date_to, percentage, orgName, groupName } = params;
   const { jsPDF } = await getPDFDeps();
 
-  const grandTotal = dailyTotals.reduce((s, d) => s + d.total_balance, 0);
+  const grandTotal = dailyTotals.reduce((s, d) => s + d.net_balance, 0);
   const percentageAmount = (grandTotal * percentage) / 100;
 
   const weekStart = dayjs(date_from).week();
@@ -204,10 +204,10 @@ export async function printRangeTotalsTicket(params: {
   drawDivider(doc, y);
   y += 3;
 
-  // Totales por día
+  // Totales por día (usa net_balance = total_balance - expenses)
   for (const entry of dailyTotals) {
     const dateLabel = dayjs(entry.date).format('DD/MM/YY');
-    lineWithAmount(doc, dateLabel, money(entry.total_balance), y);
+    lineWithAmount(doc, dateLabel, money(entry.net_balance), y);
     y += LINE_H;
   }
 

--- a/web/src/hooks/fetchs/current-account/useGetCurrentAccountTotals.ts
+++ b/web/src/hooks/fetchs/current-account/useGetCurrentAccountTotals.ts
@@ -8,6 +8,8 @@ export type DailyTotalEntry = {
   total_paid: number;
   total_bills: number;
   total_balance: number;
+  total_expenses: number;
+  net_balance: number;
 };
 
 export const currentAccountTotalsKey = (date_from?: string | null, date_to?: string | null, group_id?: string | null) =>

--- a/web/src/hooks/fetchs/org-expense/useGetOrgExpenses.ts
+++ b/web/src/hooks/fetchs/org-expense/useGetOrgExpenses.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { BACKEND_ROUTES } from '../../../../routes/routes.ts';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+
+export type OrgExpense = {
+  expense_id: string;
+  organization_id: string;
+  date: string;
+  name: string;
+  amount: number;
+};
+
+export const orgExpensesKey = (date?: string | null) =>
+  ['orgExpenses', date ?? ''] as const;
+
+export async function fetchOrgExpenses(date: string): Promise<OrgExpense[]> {
+  const res = await fetchWithAuth(
+    `${BACKEND_ROUTES.org_expense.base}?date=${encodeURIComponent(date)}`,
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  if (!res.ok) throw new Error('Error fetching expenses');
+  const json = await res.json();
+  return json?.data?.expenses ?? [];
+}
+
+export function useGetOrgExpenses(date?: string | null) {
+  return useQuery<OrgExpense[]>({
+    queryKey: orgExpensesKey(date),
+    queryFn: () => fetchOrgExpenses(date!),
+    enabled: !!date,
+    staleTime: 2 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/web/src/hooks/mutations/org-expense/useCreateOrgExpense.ts
+++ b/web/src/hooks/mutations/org-expense/useCreateOrgExpense.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { BACKEND_ROUTES } from '../../../../routes/routes.ts';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import { orgExpensesKey } from '@/hooks/fetchs/org-expense/useGetOrgExpenses';
+
+type CreateExpensePayload = { date: string; name: string; amount: number };
+
+export function useCreateOrgExpense() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CreateExpensePayload) => {
+      const res = await fetchWithAuth(BACKEND_ROUTES.org_expense.base, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Error creating expense');
+      const json = await res.json();
+      return json?.data?.expense;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: orgExpensesKey(variables.date) });
+    },
+  });
+}

--- a/web/src/hooks/mutations/org-expense/useDeleteOrgExpense.ts
+++ b/web/src/hooks/mutations/org-expense/useDeleteOrgExpense.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { BACKEND_ROUTES } from '../../../../routes/routes.ts';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import { orgExpensesKey } from '@/hooks/fetchs/org-expense/useGetOrgExpenses';
+
+export function useDeleteOrgExpense(date?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (expense_id: string) => {
+      const res = await fetchWithAuth(BACKEND_ROUTES.org_expense.id(expense_id), {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error('Error deleting expense');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orgExpensesKey(date) });
+    },
+  });
+}


### PR DESCRIPTION
…otals

Daily ticket expenses were discarded on close, so range-date totals didn't account for them and showed inconsistent saldos.

- New table org_expenses (org_id + date + name + amount)
- GET/POST/DELETE /api/private/org_expense endpoint
- PrintTotalsModal loads and saves expenses to DB per date; delete buttons remove them immediately
- GET /current_account/totals now joins org_expenses per day, returns total_expenses and net_balance = total_balance - expenses
- Range ticket uses net_balance per day and grand total