### PR TITLE
fix ticket number collision between cashiers of same org

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-18
+
+#### Ticket number uniqueness scoped to organization + cashier number suffix
+- **Root cause**: `UNIQUE (ticket_number)` was global — different organizations (or different cashiers in same org) creating tickets at the same millisecond caused false unique constraint violations.
+- **Fix**: `ticket_number` generation in `api/src/ticket/helper/ticketBase.ts` now appends the cashier's `number` as suffix (e.g. `20260418143025123-42`), making same-org same-millisecond collisions impossible in practice.
+- **`helper/request/ticket.request.ts`**: Added `user_number?: number | null` to `INewTicketEntity` — frontend sends cashier's number (handles case where admin creates on behalf of cashier: `cashier?.number ?? user!.number`).
+- **`web/src/features/make-plays/provider/MakePlaysProvider.tsx`**: Both payloads include `user_number: cashier?.number ?? user!.number`.
+- **`api/src/ticket/helper/ticketBase.ts`**: Uses `ticket.user_number` from the payload to build suffix with dash (format `YYYYMMDDHHmmssSSS-{N}`).
+- **`api/supabase/migrations/20260418203053`**: Also drops `ticket_number_numeric_only` constraint and replaces it with `ticket_number_format CHECK (ticket_number ~ '^\d+(-\d+)?$')` to allow the dash-separated suffix.
+- **`api/supabase/migrations/20260418203053_fix_unique_ticket_number_per_org.sql`**: Drops global constraint, adds `UNIQUE (ticket_number, organization_id)`.
+
 ### Added - 2026-04-16
 
 #### Totales por rango de fechas en Cuenta Corriente

--- a/api/src/ticket/helper/ticketBase.ts
+++ b/api/src/ticket/helper/ticketBase.ts
@@ -13,7 +13,8 @@ export const ticketBase = (
 ): Omit<INewTicketBaseEntity, 'organization_id'> => {
   const timestamp = dayjs().tz('America/Argentina/Buenos_Aires');
   const ticket_id = uuidv4();
-  const ticket_number = dayjs().tz('America/Argentina/Buenos_Aires').format('YYYYMMDDHHmmssSSS');
+  const base = dayjs().tz('America/Argentina/Buenos_Aires').format('YYYYMMDDHHmmssSSS');
+  const ticket_number = ticket.user_number != null ? `${base}-${ticket.user_number}` : base;
 
   const total = ticket.bets.reduce((prev, curr) => prev + curr.amount, 0);
 

--- a/api/supabase/migrations/20260418203053_fix_unique_ticket_number_per_org.sql
+++ b/api/supabase/migrations/20260418203053_fix_unique_ticket_number_per_org.sql
@@ -1,0 +1,13 @@
+-- Scope ticket_number uniqueness to organization_id.
+-- Previously global, causing false collisions between organizations
+-- and between cashiers of the same org creating tickets in the same millisecond.
+-- ticket_number now includes cashier number suffix with dash (e.g. YYYYMMDDHHmmssSSS-42),
+-- so the numeric-only constraint is relaxed to allow digits and a single optional dash suffix.
+ALTER TABLE tickets DROP CONSTRAINT IF EXISTS unique_ticket_number;
+ALTER TABLE tickets DROP CONSTRAINT IF EXISTS ticket_number_numeric_only;
+
+ALTER TABLE tickets
+ADD CONSTRAINT unique_ticket_number UNIQUE (ticket_number, organization_id);
+
+ALTER TABLE tickets
+ADD CONSTRAINT ticket_number_format CHECK (ticket_number ~ '^\d+(-\d+)?$');

--- a/helper/request/ticket.request.ts
+++ b/helper/request/ticket.request.ts
@@ -7,6 +7,7 @@ import { ILotteryEntityFront } from '../types/lottery.type';
 export type INewTicketEntity = Pick<ITicketEntityBase, 'user_id' | 'user_name' | 'date'> & {
   bets: IBetTable[];
   client_request_id?: string;
+  user_number?: number | null;
 };
 export type IEditTicketEntity = Pick<ITicketEntityBase, 'ticket_id'> & {
   bets: IBetTable[];

--- a/web/src/features/make-plays/provider/MakePlaysProvider.tsx
+++ b/web/src/features/make-plays/provider/MakePlaysProvider.tsx
@@ -197,6 +197,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
       date: today,
       user_id: cashier?.user_id ?? user!.user_id,
       user_name: `${cashier?.name ?? user!.name}-${cashier?.number ?? user!.number}`,
+      user_number: cashier?.number ?? user!.number,
       bets: bets,
       client_request_id: clientRequestIdRef.current,
     };
@@ -356,6 +357,7 @@ export const MakePlaysProvider: React.FC<React.PropsWithChildren> = ({ children 
       date: today,
       user_id: cashier?.user_id ?? user!.user_id,
       user_name: `${cashier?.name ?? user!.name}-${cashier?.number ?? user!.number}`,
+      user_number: cashier?.number ?? user!.number,
       bets: cleanedBets,
       client_request_id: clientRequestIdRef.current,
     };


### PR DESCRIPTION
- append cashier number as suffix (YYYYMMDDHHmmssSSS-N) to eliminate same-org same-millisecond race condition
- admin creating on behalf of cashier uses cashier's number via user_number field in INewTicketEntity
- migration scopes UNIQUE constraint to (ticket_number, organization_id) and relaxes numeric-only check to allow dash suffix ^\d+(-\d+)?$