### PR TITLE
fix concurrent refresh race condition causing all sessions to be revoked

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-19
+
+#### Session race condition — concurrent refresh kicks all devices
+- **`web/src/lib/apiClient.ts`**: Added `safeRefresh()` public method that checks `isRefreshing` mutex before starting a token refresh. Prevents the proactive timer from racing with a 401-triggered refresh on the same device.
+- **`web/src/providers/AuthProvider.tsx`**: `refreshAccessToken` now calls `apiClient.safeRefresh()` instead of `apiClient.post('/auth/refresh')` directly. This routes proactive refreshes through the mutex that already protects 401-triggered refreshes.
+- **Why**: When access token expired exactly as the 13-14 min proactive timer fired, two concurrent refresh requests were sent with the same refresh token cookie. The second one arrived with the already-rotated token, triggering "token reuse detected" → `revokeAllUserSessions()` → both devices logged out simultaneously.
+
 ### Fixed - 2026-04-17
 
 #### Ticket PDF — impresora térmica comprime texto

--- a/web/src/lib/apiClient.ts
+++ b/web/src/lib/apiClient.ts
@@ -207,6 +207,28 @@ class ApiClient {
     }
   }
 
+  /**
+   * Proactive token refresh that respects the isRefreshing mutex.
+   * Use this instead of posting to /auth/refresh directly to avoid
+   * concurrent refresh attempts that trigger token-reuse detection.
+   */
+  async safeRefresh(): Promise<void> {
+    if (this.isRefreshing) return; // refresh already in progress, skip
+    this.isRefreshing = true;
+    try {
+      const success = await this.refreshAccessToken();
+      if (success) {
+        this.processPendingRequests(null);
+      } else {
+        const error = new ApiError(401, { code: 'REFRESH_FAILED', message: 'Sesión expirada.' });
+        this.processPendingRequests(error);
+        throw error;
+      }
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+
   async get<T>(endpoint: string, config?: RequestConfig): Promise<T> {
     return this.request<T>(endpoint, { ...config, method: 'GET' });
   }

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -106,7 +106,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
   const refreshAccessToken = useCallback(async () => {
     try {
-      await apiClient.post(BACKEND_ROUTES.auth.refresh);
+      // safeRefresh checks isRefreshing mutex to prevent concurrent refresh attempts
+      // that would trigger token-reuse detection and revoke all sessions
+      await apiClient.safeRefresh();
     } catch (error) {
       // Refresh failed - session likely expired or no refresh token (old session)
       console.warn('[Auth] Refresh token failed, logging out:', error);


### PR DESCRIPTION
Proactive auto-refresh timer (every 13-14min) and 401-triggered refresh could fire simultaneously, sending the same refresh token twice. The second request arrived after rotation, triggering token-reuse detection which called revokeAllUserSessions — logging out all devices for that user.

Fix: apiClient.safeRefresh() checks isRefreshing mutex before starting a refresh. AuthProvider proactive timer now routes through safeRefresh instead of posting to /auth/refresh directly.