### PR TITLE
fix(auth): sign refresh token with version+1 to match rotateRefreshTo…

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-20
+
+#### Session Management
+- **Version mismatch on login**: `signRefreshToken` at login now uses `refresh_token_version + 1` to match the version stored by `rotateRefreshToken`, fixing first-refresh 401 failures that caused users to be logged out every ~13-14 minutes (`api/src/auth/controller/auth.controller.ts`)
+
 ### Fixed - 2026-04-19
 
 #### Concurrency and race condition hardening

--- a/api/src/auth/controller/auth.controller.ts
+++ b/api/src/auth/controller/auth.controller.ts
@@ -166,7 +166,7 @@ export class AuthController {
     const refreshToken = signRefreshToken(
       userData.user_id,
       session.session_id,
-      session.refresh_token_version
+      session.refresh_token_version + 1
     );
 
     // Update session with correct refresh token hash


### PR DESCRIPTION
…ken DB state

At login, signRefreshToken was called with session.refresh_token_version (=1), then rotateRefreshToken incremented the DB to version 2. On the first proactive refresh (~13-14 min), the version check (decoded.token_version !== DB version) always failed with 401, logging users out. Sliding window never ran because updateActivity() is only called after a successful version check.

Fix: sign the refresh JWT with refresh_token_version + 1 so it matches the DB value that rotateRefreshToken will store.