### PR TITLE
feat(current-account): add daily summary endpoint and two new print b…

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-20
+
+#### Cuenta Corriente — endpoint daily-summary
+- **`api/src/current-account/repository/current-account.repository.ts`**: Added `getDailySummaryByDateRange` — queries `current_accounts` for all CC fields (pass, successes, claims, subtotal, previous_balance, collections, paid, total, drag, leave), aggregates per date.
+- **`api/src/current-account/controller/current-account.controller.ts`**: Added `getDailySummaryByDateRangeHandler` delegating to repository.
+- **`api/src/current-account/route/current-account.route.ts`**: Added `GET /daily-summary?date_from&date_to&group_id` — same auth/group scoping as `/totals`. Returns `{ data: { summary: DailySummaryEntry[] } }`.
+
 ### Fixed - 2026-04-20
 
 #### Session Management

--- a/api/src/current-account/controller/current-account.controller.ts
+++ b/api/src/current-account/controller/current-account.controller.ts
@@ -271,6 +271,25 @@ export class CurrentAccountController {
     }
   };
 
+  getDailySummaryByDateRangeHandler = async (
+    organization_id: string,
+    date_from: string,
+    date_to: string,
+    user_ids?: string[]
+  ) => {
+    try {
+      return await this.repository.getDailySummaryByDateRange(
+        organization_id,
+        date_from,
+        date_to,
+        user_ids
+      );
+    } catch (error) {
+      console.error('getDailySummaryByDateRangeHandler error:', error);
+      throw error instanceof Error ? error : new Error('Unknown error');
+    }
+  };
+
   /**
    * Get network summary (aggregated totals per organization)
    */

--- a/api/src/current-account/repository/current-account.repository.ts
+++ b/api/src/current-account/repository/current-account.repository.ts
@@ -348,4 +348,91 @@ export class CurrentAccountRepository {
         };
       });
   }
+
+  async getDailySummaryByDateRange(
+    organization_id: string,
+    date_from: string,
+    date_to: string,
+    user_ids?: string[]
+  ): Promise<
+    {
+      date: string;
+      total_pass: number;
+      total_successes: number;
+      total_claims: number;
+      total_subtotal: number;
+      total_previous_balance: number;
+      total_collections: number;
+      total_paid: number;
+      total_total: number;
+      total_drag: number;
+      total_leave: number;
+    }[]
+  > {
+    const orgIds = await this.getOrganizationNetworkIds(organization_id);
+
+    let query = supabase
+      .from('current_accounts')
+      .select(
+        'date, pass, successes, claims, subtotal, previous_balance, collections, paid, total, drag, leave'
+      )
+      .in('organization_id', orgIds)
+      .gte('date', dayjs(date_from).format('YYYY-MM-DD'))
+      .lte('date', dayjs(date_to).format('YYYY-MM-DD'))
+      .order('date', { ascending: true });
+
+    if (user_ids && user_ids.length > 0) {
+      query = query.in('user_id', user_ids);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const byDate: Record<
+      string,
+      {
+        total_pass: number;
+        total_successes: number;
+        total_claims: number;
+        total_subtotal: number;
+        total_previous_balance: number;
+        total_collections: number;
+        total_paid: number;
+        total_total: number;
+        total_drag: number;
+        total_leave: number;
+      }
+    > = {};
+
+    for (const row of data ?? []) {
+      if (!byDate[row.date]) {
+        byDate[row.date] = {
+          total_pass: 0,
+          total_successes: 0,
+          total_claims: 0,
+          total_subtotal: 0,
+          total_previous_balance: 0,
+          total_collections: 0,
+          total_paid: 0,
+          total_total: 0,
+          total_drag: 0,
+          total_leave: 0,
+        };
+      }
+      byDate[row.date].total_pass += Number(row.pass) || 0;
+      byDate[row.date].total_successes += Number(row.successes) || 0;
+      byDate[row.date].total_claims += Number(row.claims) || 0;
+      byDate[row.date].total_subtotal += Number(row.subtotal) || 0;
+      byDate[row.date].total_previous_balance += Number(row.previous_balance) || 0;
+      byDate[row.date].total_collections += Number(row.collections) || 0;
+      byDate[row.date].total_paid += Number(row.paid) || 0;
+      byDate[row.date].total_total += Number(row.total) || 0;
+      byDate[row.date].total_drag += Number(row.drag) || 0;
+      byDate[row.date].total_leave += Number(row.leave) || 0;
+    }
+
+    return Object.entries(byDate)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, totals]) => ({ date, ...totals }));
+  }
 }

--- a/api/src/current-account/route/current-account.route.ts
+++ b/api/src/current-account/route/current-account.route.ts
@@ -41,6 +41,7 @@ export class CurrentAccountRouter {
   private setupRoutes() {
     this.router.get('/network/summary', this.getNetworkSummaryHandler);
     this.router.get('/totals', this.getTotalsByDateRangeHandler);
+    this.router.get('/daily-summary', this.getDailySummaryByDateRangeHandler);
     this.router.get('/:id', this.getCurrentAccountHandler);
     this.router.get('/', this.getAllCurrentAccountHandler);
     this.router.post('/calculate', this.calculateCurrentAccountHandler);
@@ -630,14 +631,12 @@ export class CurrentAccountRouter {
     }
 
     if (!date_from || !date_to || typeof date_from !== 'string' || typeof date_to !== 'string') {
-      res
-        .status(400)
-        .json({
-          error: {
-            error: ERROR_TYPE.BAD_REQUEST,
-            message: 'Query params "date_from" and "date_to" (YYYY-MM-DD) are required',
-          },
-        });
+      res.status(400).json({
+        error: {
+          error: ERROR_TYPE.BAD_REQUEST,
+          message: 'Query params "date_from" and "date_to" (YYYY-MM-DD) are required',
+        },
+      });
       return;
     }
 
@@ -665,6 +664,68 @@ export class CurrentAccountRouter {
       );
 
       res.status(200).json({ data: { totals } });
+    } catch (error) {
+      console.error(error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message } });
+    }
+  };
+
+  private getDailySummaryByDateRangeHandler: RequestHandler = async (
+    req: Request,
+    res: Response
+  ) => {
+    const { user } = req;
+    const { date_from, date_to, group_id } = req.query;
+
+    if (!user?.user) {
+      res
+        .status(400)
+        .json({ error: { error: ERROR_TYPE.BAD_REQUEST, message: ERROR_MESSAGE.BAD_REQUEST } });
+      return;
+    }
+
+    if (user.user.user_type === USER_TYPE.CASHIER) {
+      res.status(403).json({ error: { error: ERROR_TYPE.AUTH_ERROR, message: 'Access denied' } });
+      return;
+    }
+
+    if (!date_from || !date_to || typeof date_from !== 'string' || typeof date_to !== 'string') {
+      res
+        .status(400)
+        .json({
+          error: {
+            error: ERROR_TYPE.BAD_REQUEST,
+            message: 'Query params "date_from" and "date_to" (YYYY-MM-DD) are required',
+          },
+        });
+      return;
+    }
+
+    try {
+      let user_ids: string[] | undefined;
+
+      if (
+        user.user.user_type === USER_TYPE.ADMIN &&
+        user.user.group_id &&
+        user.user.group_id !== req.organization_id
+      ) {
+        user_ids = await this.userRepository.getUserIdsByGroupId(
+          user.user.group_id,
+          req.organization_id!
+        );
+      } else if (typeof group_id === 'string') {
+        user_ids = await this.userRepository.getUserIdsByGroupId(group_id, req.organization_id!);
+      }
+
+      const summary = await this.controller.getDailySummaryByDateRangeHandler(
+        req.organization_id!,
+        date_from,
+        date_to,
+        user_ids
+      );
+
+      res.status(200).json({ data: { summary } });
     } catch (error) {
       console.error(error);
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-20
+
+#### Cuenta Corriente — Totales CC (A4) y Subtotales (ticket)
+- **`web/src/hooks/fetchs/current-account/useGetCurrentAccountDailySummary.ts`**: New fetch hook `fetchCurrentAccountDailySummary(date_from, date_to, group_id)` calling `GET /daily-summary`. Returns `DailySummaryEntry[]` with all CC fields aggregated per day.
+- **`web/src/functions/printLiquidationAdmin.ts`**: Added `downloadCurrentAccountDailySummaryPDF` — A4 landscape PDF with one row per date; columns: Fecha, Pase, Aciertos, Reclamos, Subtotal, Deuda, Cobros, Pagos, Total, Arrastre, Deje + totals footer.
+- **`web/src/functions/printTotalsTicket.ts`**: Added `printSubtotalsDayTicket` (per-cashier subtotals for a single day) and `printSubtotalsRangeTicket` (per-day subtotals for a date range).
+- **`web/src/components/modals/PrintDailySummaryModal.tsx`**: Modal for button 1 — date range + group selector, prints A4 daily summary PDF.
+- **`web/src/components/modals/PrintSubtotalsModal.tsx`**: Modal for button 2 — day/range mode + group selector, prints subtotals ticket.
+- **`web/src/features/current-account/index.tsx`**: Added "Totales CC (A4)" and "Imprimir Subtotales" buttons; lazy-loaded new modals.
+- **`web/routes/routes.ts`**: Added `daily_summary` route to `current_account`.
+
 ### Fixed - 2026-04-19
 
 #### Session race condition — concurrent refresh kicks all devices

--- a/web/routes/routes.ts
+++ b/web/routes/routes.ts
@@ -56,6 +56,7 @@ export const BACKEND_ROUTES = {
     calculate: `${PRIVATE}/current_account/calculate`,
     liquidate: `${PRIVATE}/current_account/liquidate`,
     totals: `${PRIVATE}/current_account/totals`,
+    daily_summary: `${PRIVATE}/current_account/daily-summary`,
   },
   results: {
     base: `${PRIVATE}/results`,

--- a/web/src/components/modals/PrintDailySummaryModal.tsx
+++ b/web/src/components/modals/PrintDailySummaryModal.tsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+import toast from 'react-hot-toast';
+import Modal from './custom-modal';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SelectDayToSearch } from '@/components/button/SelectDayToSearch';
+import { useAuth } from '@/contexts/AuthContext';
+import { useGroups } from '@/hooks/fetchs/organization/useGroups';
+import { fetchCurrentAccountDailySummary } from '@/hooks/fetchs/current-account/useGetCurrentAccountDailySummary';
+import { downloadCurrentAccountDailySummaryPDF } from '@/functions/printLiquidationAdmin';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import { BACKEND_ROUTES } from '../../../routes/routes';
+
+const ALL_GROUPS = '__all__';
+
+interface PrintDailySummaryModalProps {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  initialDate?: string | null;
+  initialGroupId?: string | null;
+}
+
+const PrintDailySummaryModal = ({
+  isOpen,
+  onClose,
+  initialDate,
+  initialGroupId,
+}: PrintDailySummaryModalProps) => {
+  const { organizationId, role } = useAuth();
+  const { data: groups } = useGroups(organizationId, role);
+
+  const [dateFrom, setDateFrom] = useState<string>(
+    initialDate ?? dayjs().startOf('week').format('YYYY-MM-DD')
+  );
+  const [dateTo, setDateTo] = useState<string>(
+    initialDate ?? dayjs().format('YYYY-MM-DD')
+  );
+  const [groupId, setGroupId] = useState<string>(initialGroupId || ALL_GROUPS);
+  const [printing, setPrinting] = useState(false);
+  const [orgName, setOrgName] = useState<string>('');
+
+  const effectiveGroupId = groupId === ALL_GROUPS ? null : groupId;
+
+  useEffect(() => {
+    if (!isOpen || !organizationId) return;
+    fetchWithAuth(BACKEND_ROUTES.organization.id(organizationId))
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => setOrgName(json?.data?.organization?.name ?? ''))
+      .catch(() => setOrgName(''));
+  }, [isOpen, organizationId]);
+
+  const handlePrint = async () => {
+    try {
+      setPrinting(true);
+      const data = await fetchCurrentAccountDailySummary(dateFrom, dateTo, effectiveGroupId);
+      if (!data.length) {
+        toast.error('Sin datos para ese período.');
+        return;
+      }
+      await downloadCurrentAccountDailySummaryPDF({ date_from: dateFrom, date_to: dateTo, data });
+      toast.success('PDF generado.');
+      onClose();
+    } catch {
+      toast.error('Error al generar el PDF.');
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Totales Cuenta Corriente (A4)" className="max-w-md">
+      <div className="space-y-4">
+        {groups && groups.length > 0 && (
+          <div className="space-y-1">
+            <Label>Grupo</Label>
+            <Select value={groupId} onValueChange={setGroupId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todos los grupos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_GROUPS}>Todos los grupos</SelectItem>
+                {groups.map((g) => (
+                  <SelectItem key={g.organization_id} value={g.organization_id}>
+                    {g.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <Label>Desde</Label>
+          <SelectDayToSearch
+            selectedDay={dateFrom}
+            onDayChange={(d) => d && setDateFrom(d)}
+            className="w-full"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Hasta</Label>
+          <SelectDayToSearch
+            selectedDay={dateTo}
+            onDayChange={(d) => d && setDateTo(d)}
+            className="w-full"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={printing}>
+            Cancelar
+          </Button>
+          <Button onClick={handlePrint} disabled={printing}>
+            {printing ? 'Generando...' : 'Imprimir'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PrintDailySummaryModal;

--- a/web/src/components/modals/PrintSubtotalsModal.tsx
+++ b/web/src/components/modals/PrintSubtotalsModal.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+import toast from 'react-hot-toast';
+import Modal from './custom-modal';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SelectDayToSearch } from '@/components/button/SelectDayToSearch';
+import { useAuth } from '@/contexts/AuthContext';
+import { useGroups } from '@/hooks/fetchs/organization/useGroups';
+import { fetchCurrentAccount } from '@/hooks/fetchs/current-account/useGetCurrentAccount';
+import { fetchCurrentAccountDailySummary } from '@/hooks/fetchs/current-account/useGetCurrentAccountDailySummary';
+import { printSubtotalsDayTicket, printSubtotalsRangeTicket } from '@/functions/printTotalsTicket';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import { BACKEND_ROUTES } from '../../../routes/routes';
+
+const ALL_GROUPS = '__all__';
+
+interface PrintSubtotalsModalProps {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  initialDate?: string | null;
+  initialGroupId?: string | null;
+}
+
+const PrintSubtotalsModal = ({
+  isOpen,
+  onClose,
+  initialDate,
+  initialGroupId,
+}: PrintSubtotalsModalProps) => {
+  const { organizationId, role } = useAuth();
+  const { data: groups } = useGroups(organizationId, role);
+
+  const [mode, setMode] = useState<'day' | 'range'>('day');
+  const [date, setDate] = useState<string>(initialDate ?? dayjs().format('YYYY-MM-DD'));
+  const [dateFrom, setDateFrom] = useState<string>(dayjs().startOf('week').format('YYYY-MM-DD'));
+  const [dateTo, setDateTo] = useState<string>(dayjs().format('YYYY-MM-DD'));
+  const [groupId, setGroupId] = useState<string>(initialGroupId || ALL_GROUPS);
+  const [printing, setPrinting] = useState(false);
+  const [orgName, setOrgName] = useState<string>('');
+
+  const effectiveGroupId = groupId === ALL_GROUPS ? null : groupId;
+  const selectedGroup = groups?.find((g) => g.organization_id === groupId);
+
+  useEffect(() => {
+    if (!isOpen || !organizationId) return;
+    fetchWithAuth(BACKEND_ROUTES.organization.id(organizationId))
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => setOrgName(json?.data?.organization?.name ?? ''))
+      .catch(() => setOrgName(''));
+  }, [isOpen, organizationId]);
+
+  const handlePrint = async () => {
+    try {
+      setPrinting(true);
+
+      if (mode === 'day') {
+        const data = await fetchCurrentAccount(date, effectiveGroupId);
+        if (!data.length) {
+          toast.error('Sin datos para esa fecha.');
+          return;
+        }
+        await printSubtotalsDayTicket({
+          data,
+          date,
+          orgName,
+          groupName: selectedGroup?.name,
+        });
+      } else {
+        const dailySummary = await fetchCurrentAccountDailySummary(dateFrom, dateTo, effectiveGroupId);
+        if (!dailySummary.length) {
+          toast.error('Sin datos para ese rango.');
+          return;
+        }
+        await printSubtotalsRangeTicket({
+          dailySummary,
+          date_from: dateFrom,
+          date_to: dateTo,
+          orgName,
+          groupName: selectedGroup?.name,
+        });
+      }
+
+      toast.success('Ticket generado.');
+      onClose();
+    } catch {
+      toast.error('Error al generar el ticket.');
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Imprimir Subtotales" className="max-w-md">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Tipo de reporte</Label>
+          <RadioGroup
+            value={mode}
+            onValueChange={(v) => setMode(v as 'day' | 'range')}
+            className="flex gap-4"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="day" id="sub-mode-day" />
+              <Label htmlFor="sub-mode-day" className="cursor-pointer">
+                Día
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="range" id="sub-mode-range" />
+              <Label htmlFor="sub-mode-range" className="cursor-pointer">
+                Rango de fechas
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {groups && groups.length > 0 && (
+          <div className="space-y-1">
+            <Label>Grupo</Label>
+            <Select value={groupId} onValueChange={setGroupId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todos los grupos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_GROUPS}>Todos los grupos</SelectItem>
+                {groups.map((g) => (
+                  <SelectItem key={g.organization_id} value={g.organization_id}>
+                    {g.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {mode === 'day' && (
+          <div className="space-y-1">
+            <Label>Fecha</Label>
+            <SelectDayToSearch
+              selectedDay={date}
+              onDayChange={(d) => d && setDate(d)}
+              className="w-full"
+            />
+          </div>
+        )}
+
+        {mode === 'range' && (
+          <>
+            <div className="space-y-1">
+              <Label>Desde</Label>
+              <SelectDayToSearch
+                selectedDay={dateFrom}
+                onDayChange={(d) => d && setDateFrom(d)}
+                className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Hasta</Label>
+              <SelectDayToSearch
+                selectedDay={dateTo}
+                onDayChange={(d) => d && setDateTo(d)}
+                className="w-full"
+              />
+            </div>
+          </>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={printing}>
+            Cancelar
+          </Button>
+          <Button onClick={handlePrint} disabled={printing}>
+            {printing ? 'Generando...' : 'Imprimir'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PrintSubtotalsModal;

--- a/web/src/features/current-account/index.tsx
+++ b/web/src/features/current-account/index.tsx
@@ -28,6 +28,10 @@ const CurrentAccountContent = () => {
   const [open, setOpen] = useState<boolean>(false);
   const [openPrintTotals, setOpenPrintTotals] = useState<boolean>(false);
   const [printTotalsKey, setPrintTotalsKey] = useState(0);
+  const [openDailySummary, setOpenDailySummary] = useState<boolean>(false);
+  const [dailySummaryKey, setDailySummaryKey] = useState(0);
+  const [openSubtotals, setOpenSubtotals] = useState<boolean>(false);
+  const [subtotalsKey, setSubtotalsKey] = useState(0);
   const { role } = useAuth();
   const [searchParams] = useSearchParams();
   const { mutate: calculateCurrentAccount } = useCalculateCurrentAccount();
@@ -138,6 +142,12 @@ const CurrentAccountContent = () => {
             <Button variant={'outline'} onClick={() => { setPrintTotalsKey((k) => k + 1); setOpenPrintTotals(true); }} disabled={printing}>
               Exportar Cobros y Pagos
             </Button>
+            <Button variant={'outline'} onClick={() => { setDailySummaryKey((k) => k + 1); setOpenDailySummary(true); }} disabled={printing}>
+              Totales CC (A4)
+            </Button>
+            <Button variant={'outline'} onClick={() => { setSubtotalsKey((k) => k + 1); setOpenSubtotals(true); }} disabled={printing}>
+              Imprimir Subtotales
+            </Button>
             <Button variant={'outline'} onClick={handleUpdateCurrentAccount}>
               Actualizar
             </Button>
@@ -162,6 +172,24 @@ const CurrentAccountContent = () => {
           initialGroupId={group_id}
         />
       </Suspense>
+      <Suspense>
+        <PrintDailySummaryModal
+          key={dailySummaryKey}
+          isOpen={openDailySummary}
+          onClose={() => setOpenDailySummary(false)}
+          initialDate={date}
+          initialGroupId={group_id}
+        />
+      </Suspense>
+      <Suspense>
+        <PrintSubtotalsModal
+          key={subtotalsKey}
+          isOpen={openSubtotals}
+          onClose={() => setOpenSubtotals(false)}
+          initialDate={date}
+          initialGroupId={group_id}
+        />
+      </Suspense>
     </PageWrapper>
   );
 };
@@ -174,4 +202,12 @@ const GenerateLiquitationModal = React.lazy(
 
 const PrintTotalsModal = React.lazy(
   () => import('../../components/modals/PrintTotalsModal')
+);
+
+const PrintDailySummaryModal = React.lazy(
+  () => import('../../components/modals/PrintDailySummaryModal')
+);
+
+const PrintSubtotalsModal = React.lazy(
+  () => import('../../components/modals/PrintSubtotalsModal')
 );

--- a/web/src/functions/printLiquidationAdmin.ts
+++ b/web/src/functions/printLiquidationAdmin.ts
@@ -295,6 +295,139 @@ export async function printDiaryLiquidationAdmin(params: {
   doc.save(`LiquidacionGeneral-${dateStr}.pdf`);
 }
 
+/** PDF A4 con totales por fecha (una fila por día, sin detalle por cashier) */
+export async function downloadCurrentAccountDailySummaryPDF(params: {
+  date_from: string;
+  date_to: string;
+  data: import('@/hooks/fetchs/current-account/useGetCurrentAccountDailySummary').DailySummaryEntry[];
+}) {
+  const BASE_FONT = 8;
+  const CELL_PAD = 1;
+  const { jsPDF, autoTable } = await getPDFDeps();
+
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+
+  const fromStr = dayjs(params.date_from).format('DD/MM/YYYY');
+  const toStr = dayjs(params.date_to).format('DD/MM/YYYY');
+
+  doc.setFontSize(14);
+  doc.text('Totales Cuenta Corriente', 14, 14);
+  doc.setFontSize(10);
+  doc.text(`Período: ${fromStr} al ${toStr}`, 14, 20);
+  doc.setFontSize(BASE_FONT);
+
+  const margin = { left: 14, right: 14 };
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const available = pageWidth - margin.left - margin.right;
+
+  const worstMoney = '-9.999.999,9';
+  const MONEY_W_TEXT = doc.getTextWidth(worstMoney);
+  const minMoneyCol = MONEY_W_TEXT + CELL_PAD * 2 + 0.5;
+
+  const DATE_COL = 22;
+  const MONEY_COL_COUNT = 10;
+
+  let moneyColWidth = Math.ceil(minMoneyCol);
+  let used = DATE_COL + moneyColWidth * MONEY_COL_COUNT;
+  let leftover = available - used;
+
+  if (leftover > 0) {
+    moneyColWidth = Math.floor(moneyColWidth + leftover / MONEY_COL_COUNT);
+    used = DATE_COL + moneyColWidth * MONEY_COL_COUNT;
+    leftover = available - used;
+  }
+
+  const dateColWidth = DATE_COL + Math.max(0, leftover);
+
+  const columnStyles: Record<number, any> = {
+    0: { cellWidth: dateColWidth, halign: 'left', overflow: 'ellipsize' },
+    1: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    2: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    3: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    4: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    5: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    6: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    7: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    8: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    9: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+    10: { cellWidth: moneyColWidth, halign: 'right', overflow: 'hidden' },
+  };
+
+  const baseStyles = {
+    ...BORDER_CELL,
+    fontSize: BASE_FONT,
+    cellPadding: CELL_PAD,
+    overflow: 'linebreak',
+    fillColor: [255, 255, 255],
+    textColor: [0, 0, 0],
+  };
+
+  const HEAD = [['Fecha', 'Pase', 'Aciertos', 'Reclamos', 'Subtotal', 'Deuda', 'Cobros', 'Pagos', 'Total', 'Arrastre', 'Deje']];
+
+  const body = params.data.map((d) => [
+    dayjs(d.date).format('DD/MM/YYYY'),
+    money(d.total_pass),
+    money(d.total_successes),
+    money(d.total_claims),
+    money(d.total_subtotal),
+    money(d.total_previous_balance),
+    money(d.total_collections),
+    money(d.total_paid),
+    money(d.total_total),
+    money(d.total_drag),
+    money(d.total_leave),
+  ]);
+
+  autoTable(doc, {
+    head: HEAD,
+    body,
+    startY: 26,
+    margin,
+    theme: 'grid',
+    ...BORDER_TABLE,
+    styles: baseStyles,
+    headStyles: { ...BORDER_CELL, halign: 'center', fontSize: BASE_FONT, fillColor: [255, 255, 255], textColor: [0, 0, 0] },
+    bodyStyles: { ...BORDER_CELL, fillColor: [255, 255, 255], textColor: [0, 0, 0] },
+    alternateRowStyles: { fillColor: [255, 255, 255] },
+    columnStyles,
+    tableWidth: available,
+  });
+
+  const finalY = (doc as any).lastAutoTable?.finalY ?? 26;
+
+  const totalsRow = [
+    'Totales',
+    money(params.data.reduce((s, d) => s + d.total_pass, 0)),
+    money(params.data.reduce((s, d) => s + d.total_successes, 0)),
+    money(params.data.reduce((s, d) => s + d.total_claims, 0)),
+    money(params.data.reduce((s, d) => s + d.total_subtotal, 0)),
+    money(params.data.reduce((s, d) => s + d.total_previous_balance, 0)),
+    money(params.data.reduce((s, d) => s + d.total_collections, 0)),
+    money(params.data.reduce((s, d) => s + d.total_paid, 0)),
+    money(params.data.reduce((s, d) => s + d.total_total, 0)),
+    money(params.data.reduce((s, d) => s + d.total_drag, 0)),
+    money(params.data.reduce((s, d) => s + d.total_leave, 0)),
+  ];
+
+  autoTable(doc, {
+    startY: finalY + 6,
+    head: [['', 'Pase', 'Aciertos', 'Reclamos', 'Subtotal', 'Deuda', 'Cobros', 'Pagos', 'Total', 'Arrastre', 'Deje']],
+    body: [totalsRow],
+    margin,
+    theme: 'grid',
+    ...BORDER_TABLE,
+    styles: baseStyles,
+    headStyles: { ...BORDER_CELL, halign: 'center', fontSize: BASE_FONT, fillColor: [255, 255, 255], textColor: [0, 0, 0] },
+    bodyStyles: { ...BORDER_CELL, fillColor: [255, 255, 255], textColor: [0, 0, 0] },
+    alternateRowStyles: { fillColor: [255, 255, 255] },
+    columnStyles,
+    tableWidth: available,
+  });
+
+  addFooterPageNumbers(doc);
+  doc.save(`TotalesCC_${fromStr.replace(/\//g, '-')}_${toStr.replace(/\//g, '-')}.pdf`);
+}
+
 export const computeTotals = (rows: ICurrentAccountEntityFront[]) =>
   rows.reduce(
     (acc, it) => ({

--- a/web/src/functions/printTotalsTicket.ts
+++ b/web/src/functions/printTotalsTicket.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { ICurrentAccountEntityFront } from '@helper/types/current_account.type';
 import { DailyTotalEntry } from '@/hooks/fetchs/current-account/useGetCurrentAccountTotals';
+import { DailySummaryEntry } from '@/hooks/fetchs/current-account/useGetCurrentAccountDailySummary';
 import { printPdfBlob } from './makeTicket';
 
 const PAPER_W = 58;
@@ -174,6 +175,105 @@ export async function printRangeTotalsTicket(params: {
     format: [PAPER_W, docHeight],
   });
 
+  doc.setFont('courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+
+  let y = MARGIN + 4;
+  for (const line of lines) {
+    doc.text(line, MARGIN, y);
+    y += LINE_H;
+  }
+
+  printPdfBlob(doc.output('blob'));
+}
+
+export async function printSubtotalsDayTicket(params: {
+  data: ICurrentAccountEntityFront[];
+  date: string;
+  orgName: string;
+  groupName?: string;
+}) {
+  const { data, date, orgName, groupName } = params;
+  const { jsPDF } = await getPDFDeps();
+
+  const dateStr = dayjs(date).format('DD/MM/YYYY');
+  const timeStr = dayjs().format('HH:mm');
+  const grandTotal = data.reduce((s, a) => s + (a.subtotal ?? 0), 0);
+
+  const lines: string[] = [];
+
+  if (orgName) lines.push(centerLine(orgName.toUpperCase()));
+  if (groupName) lines.push(centerLine(groupName.toUpperCase()));
+  lines.push(centerLine('SUBTOTALES DEL DIA'));
+  lines.push(centerLine(`FECHA: ${dateStr} ${timeStr}`));
+  lines.push(DIVIDER);
+  lines.push(padLine('Nro'.padEnd(NUM_COL) + ' Nombre', 'Subtotal'));
+  lines.push(DIVIDER);
+
+  for (const acc of data) {
+    const label = `${String(acc.user_number).padEnd(NUM_COL)} ${(acc.user_name ?? '').substring(0, 14)}`;
+    lines.push(padLine(label, money(acc.subtotal ?? 0)));
+  }
+
+  lines.push(DIVIDER);
+  lines.push(padLine('TOTAL:', money(grandTotal)));
+  lines.push(DIVIDER);
+  lines.push(DIVIDER);
+  lines.push(DIVIDER);
+
+  const docHeight = Math.max(80, lines.length * LINE_H + MARGIN * 2 + 4);
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [PAPER_W, docHeight] });
+  doc.setFont('courier', 'normal');
+  doc.setFontSize(FONT_SIZE);
+
+  let y = MARGIN + 4;
+  for (const line of lines) {
+    doc.text(line, MARGIN, y);
+    y += LINE_H;
+  }
+
+  printPdfBlob(doc.output('blob'));
+}
+
+export async function printSubtotalsRangeTicket(params: {
+  dailySummary: DailySummaryEntry[];
+  date_from: string;
+  date_to: string;
+  orgName: string;
+  groupName?: string;
+}) {
+  const { dailySummary, date_from, date_to, orgName, groupName } = params;
+  const { jsPDF } = await getPDFDeps();
+
+  const fromStr = dayjs(date_from).format('DD/MM/YYYY');
+  const toStr = dayjs(date_to).format('DD/MM/YYYY');
+  const timeStr = dayjs().format('HH:mm');
+  const grandTotal = dailySummary.reduce((s, d) => s + d.total_subtotal, 0);
+
+  const lines: string[] = [];
+
+  if (orgName) lines.push(centerLine(orgName.toUpperCase()));
+  if (groupName) lines.push(centerLine(groupName.toUpperCase()));
+  lines.push(centerLine('SUBTOTALES POR FECHA'));
+  lines.push(centerLine(`${fromStr} AL ${toStr}`));
+  lines.push(centerLine(`HORA: ${timeStr}`));
+  lines.push(DIVIDER);
+  lines.push(padLine('Fecha'.padEnd(9), 'Subtotal'));
+  lines.push(DIVIDER);
+
+  for (const entry of dailySummary) {
+    const dateLabel = dayjs(entry.date).format('DD/MM/YY');
+    lines.push(padLine(dateLabel, money(entry.total_subtotal)));
+  }
+
+  lines.push(DIVIDER);
+  lines.push(padLine('TOTAL:', money(grandTotal)));
+  lines.push(DIVIDER);
+  lines.push(DIVIDER);
+  lines.push(DIVIDER);
+
+  const docHeight = Math.max(80, lines.length * LINE_H + MARGIN * 2 + 4);
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [PAPER_W, docHeight] });
   doc.setFont('courier', 'normal');
   doc.setFontSize(FONT_SIZE);
 

--- a/web/src/hooks/fetchs/current-account/useGetCurrentAccountDailySummary.ts
+++ b/web/src/hooks/fetchs/current-account/useGetCurrentAccountDailySummary.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { BACKEND_ROUTES } from '../../../../routes/routes.ts';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+
+export type DailySummaryEntry = {
+  date: string;
+  total_pass: number;
+  total_successes: number;
+  total_claims: number;
+  total_subtotal: number;
+  total_previous_balance: number;
+  total_collections: number;
+  total_paid: number;
+  total_total: number;
+  total_drag: number;
+  total_leave: number;
+};
+
+export const currentAccountDailySummaryKey = (
+  date_from?: string | null,
+  date_to?: string | null,
+  group_id?: string | null
+) => ['getCurrentAccountDailySummary', date_from ?? '', date_to ?? '', group_id ?? ''] as const;
+
+export async function fetchCurrentAccountDailySummary(
+  date_from: string,
+  date_to: string,
+  group_id?: string | null
+): Promise<DailySummaryEntry[]> {
+  const params = new URLSearchParams({ date_from, date_to });
+  if (group_id) params.set('group_id', group_id);
+
+  const res = await fetchWithAuth(
+    `${BACKEND_ROUTES.current_account.daily_summary}?${params.toString()}`,
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  if (!res.ok) throw new Error('Error fetching daily summary');
+
+  const json = await res.json();
+  return json?.data?.summary ?? [];
+}
+
+export function useGetCurrentAccountDailySummary(
+  date_from?: string | null,
+  date_to?: string | null,
+  group_id?: string | null
+) {
+  return useQuery<DailySummaryEntry[]>({
+    queryKey: currentAccountDailySummaryKey(date_from, date_to, group_id),
+    queryFn: () => fetchCurrentAccountDailySummary(date_from!, date_to!, group_id),
+    enabled: !!date_from && !!date_to,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
…uttons

- GET /daily-summary: aggregates all CC fields (pass, successes, claims, subtotal, etc.) per day for a date range
- Button 1 "Totales CC (A4)": A4 landscape PDF with one row per date, all columns + totals footer
- Button 2 "Imprimir Subtotales": thermal ticket — per-cashier subtotals for a day, or per-day subtotals for a range