### PR TITLE
feat(web): improve UX/UI responsiveness across all pages

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to the Web workspace are documented in this file.
 
 ### Added - 2026-04-20
 
+#### UX/UI General — Mobile responsiveness & layout improvements
+- **`web/src/components/mobile-bottom-nav/index.tsx`**: New bottom tab bar for mobile (`md:hidden`). Shows 4 main routes (Jugadas, Aciertos, Ticket, Resultados) + "Más" button that opens the existing sidebar Sheet via `useSidebar().toggleSidebar()`. Fixed at bottom with safe-area inset support.
+- **`web/src/components/layout/index.tsx`**: Added `MobileBottomNav`, max-width container (`max-w-[1440px]`) on content, increased mobile padding (`px-3`), added `pb-16 md:pb-0` to reserve space for bottom nav.
+
+### Changed - 2026-04-20
+
+#### UX/UI General — Mobile responsiveness & layout improvements
+- **`web/src/styles/index.css`**: Fixed CSS variable typos: `--bg-accen` → `--bg-accent`, `--border-top` → `--rounded-top`.
+- **`web/src/components/footer/index.tsx`**: Footer now shows time and date on same line on mobile (flex-row). Reduced clock font size for mobile (`text-xl sm:text-2xl 1440:text-4xl`).
+- **`web/src/components/wrapper/PageWrapper.tsx`**: Increased gap between sections (`gap-2 sm:gap-3 2xl:gap-4`).
+- **`web/src/components/header-section/index.tsx`**: Title now visible on all screen sizes (removed `hidden sm:flex`). Icon hidden on mobile only. Added `bg-background z-10` for sticky behavior. Hoisted `useMediaQuery` call to component top level.
+- **`web/src/components/button/IconButton.tsx`**: Increased mobile touch target (`h-7` → `h-10`).
+- **`web/src/constants/SidebarMenu.tsx`**: Fixed typos "Qunielas y Turnos" → "Quinielas y Turnos" and "Qunielas a jugarse" → "Quinielas a jugarse".
+- **`web/src/components/button/SelectDayToSearch.tsx`**: Calendar now starts on Sunday (`weekStartsOn: 0`).
+- **`web/src/components/modals/PrintTotalsModal.tsx`**: Added `toDate={dayjs().toDate()}` to all calendar pickers — max date is today.
+- **`web/src/components/modals/PrintDailySummaryModal.tsx`**: Added `toDate={dayjs().toDate()}` to dateFrom and dateTo pickers.
+- **`web/src/components/modals/PrintSubtotalsModal.tsx`**: Added `toDate={dayjs().toDate()}` to all calendar pickers.
+- **`web/src/features/upcoming-lotteries/index.tsx`**: Hoisted `useMediaQuery` calls. Save button now responsive (`w-full sm:w-[200px]`). Reduced padding on sections for mobile.
+- **`web/src/features/user-list/user-table.tsx`**: Table wrapper now uses `overflow-x-auto`, table has `min-w-[700px]` — horizontal scroll on mobile.
+- **`web/src/features/groups/index.tsx`**: Two-column grid now responsive (`grid-cols-1 md:grid-cols-2`).
+- **`web/src/features/organizations/index.tsx`**: Table wrapped in `overflow-x-auto`. ID column hidden on mobile (shown on sm+). Action button labels hidden on mobile (icon only). UUID truncated to 8 chars with full UUID as title tooltip.
+- **`web/src/features/current-account/index.tsx`**: Export button grid now `grid-cols-1 sm:grid-cols-2` — single column on mobile for easier tapping.
+- **`web/src/features/make-plays/fill-out-a-ticket.tsx`**: Fixed `flex-col-reverse` → `flex-col` so form appears first on mobile (before lottery checkboxes).
+- **`web/src/features/make-plays/results-overview.tsx`**: Added `border-t border-border shadow-[0_-4px_12px_rgba(0,0,0,0.3)]` to visually separate sticky action bar from content.
+
+### Added - 2026-04-20
+
+#### Cuenta Corriente — Totales CC (A4) y Subtotales (ticket)
+
 #### Cuenta Corriente — Totales CC (A4) y Subtotales (ticket)
 - **`web/src/hooks/fetchs/current-account/useGetCurrentAccountDailySummary.ts`**: New fetch hook `fetchCurrentAccountDailySummary(date_from, date_to, group_id)` calling `GET /daily-summary`. Returns `DailySummaryEntry[]` with all CC fields aggregated per day.
 - **`web/src/functions/printLiquidationAdmin.ts`**: Added `downloadCurrentAccountDailySummaryPDF` — A4 landscape PDF with one row per date; columns: Fecha, Pase, Aciertos, Reclamos, Subtotal, Deuda, Cobros, Pagos, Total, Arrastre, Deje + totals footer.

--- a/web/src/components/button/IconButton.tsx
+++ b/web/src/components/button/IconButton.tsx
@@ -27,7 +27,7 @@ export const IconButton = ({
       variant={variant}
       disabled={disabled}
       onClick={onClick}
-      className={cn('w-full sm:w-auto h-7 sm:h-auto flex items-center gap-1 lg:gap-2 justify-center px-2 py-1 lg:px-4 lg:py-2 cursor-pointer  2xl:px-6 2xl:py-4', className)}
+      className={cn('w-full sm:w-auto h-10 sm:h-auto flex items-center gap-1 lg:gap-2 justify-center px-2 py-1 lg:px-4 lg:py-2 cursor-pointer  2xl:px-6 2xl:py-4', className)}
     >
       {icon && <span className="hidden md:inline flex-shrink-0">{icon}</span>}
       <span className="truncate text-xs md:text-sm lg:text-base 2xl:text-lg text-nowrap">{label}</span>

--- a/web/src/components/button/SelectDayToSearch.tsx
+++ b/web/src/components/button/SelectDayToSearch.tsx
@@ -77,6 +77,7 @@ export function SelectDayToSearch({
             onSelect={handleSelect}
             locale={es}
             toDate={toDate}
+            weekStartsOn={0}
             initialFocus
             className={cn('p-2 sm:p-3 pointer-events-auto')}
           />

--- a/web/src/components/footer/index.tsx
+++ b/web/src/components/footer/index.tsx
@@ -5,10 +5,10 @@ const Footer = memo(function Footer() {
   const { time, date } = useClock();
 
   return (
-    <div className="flex justify-end bg-[var(--primary-bg-content)] text-white 1440:py-4 py-1 border-t border-gray-700 px-8">
-      <div className="text-right">
-        <div className="text-4xl font-semibold text-primary">{time}</div>
-        <div className="text-sm text-gray-400">{date}</div>
+    <div className="flex justify-end bg-[var(--primary-bg-content)] text-white 1440:py-4 py-1 border-t border-gray-700 px-4 sm:px-8">
+      <div className="flex flex-row items-center gap-3 sm:flex-col sm:items-end sm:gap-0 text-right">
+        <div className="text-xl sm:text-2xl 1440:text-4xl font-semibold text-primary">{time}</div>
+        <div className="text-xs sm:text-sm text-gray-400">{date}</div>
       </div>
     </div>
   );

--- a/web/src/components/header-section/index.tsx
+++ b/web/src/components/header-section/index.tsx
@@ -12,18 +12,19 @@ interface HeaderSectionProps {
 }
 
 const HeaderSection = ({ title, children, className }: HeaderSectionProps) => {
+  const isLarge = useMediaQuery('(min-width: 1440px)');
   return (
     <Flex
-      className={`${cn(className)} items-center lg:flex-row  justify-between  border-b p-1 2xl:p-2`}
+      className={`${cn(className)} items-center lg:flex-row justify-between border-b p-1 2xl:p-2 bg-background z-10`}
     >
-      <Flex className={' hidden sm:flex items-center gap-4'}>
-        <span>
+      <Flex className={'flex items-center gap-2 sm:gap-4'}>
+        <span className="hidden sm:inline">
           <Combine
             className={'text-[--text-secondary]'}
-            size={useMediaQuery('(min-width: 1440px)') ? '24px' : '16px'}
+            size={isLarge ? '24px' : '16px'}
           />
         </span>
-        <p className={'1440:text-2xl text-md font-medium text-nowrap'}>{title}</p>
+        <p className={'1440:text-2xl text-sm sm:text-base font-medium text-nowrap'}>{title}</p>
       </Flex>
       {children}
     </Flex>

--- a/web/src/components/layout/index.tsx
+++ b/web/src/components/layout/index.tsx
@@ -5,6 +5,7 @@ import { Outlet, useNavigation } from 'react-router-dom';
 import Footer from '../footer';
 import Header from '../header';
 import Aside from '@/components/aside';
+import MobileBottomNav from '@/components/mobile-bottom-nav';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { Flex, FlexCol } from '../flex';
 import { cn } from '@/lib/utils';
@@ -31,7 +32,7 @@ const Layout = () => {
           <Header setIsOpen={toggleSidebar} />
 
           <main
-            className="flex flex-1 w-full max-w-full mx-auto min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-2 py-1 sm:px-2 xl:px-3 2xl:px-4 2xl:py-2  justify-center"
+            className="flex flex-1 w-full max-w-full mx-auto min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-3 py-1 sm:px-3 xl:px-4 2xl:px-5 2xl:py-2 justify-center pb-16 md:pb-0"
             style={{
               scrollbarWidth: 'thin',
               scrollbarColor: '#666 transparent',
@@ -43,10 +44,12 @@ const Layout = () => {
               </div>
             )}
 
-            {/* 🔧 centra contenido y limita ancho */}
-            <Outlet />
+            <div className="w-full max-w-[1440px] flex flex-col flex-1 min-h-0">
+              <Outlet />
+            </div>
           </main>
           <Footer />
+          <MobileBottomNav />
         </FlexCol>
       </Flex>
     </SidebarProvider>

--- a/web/src/components/mobile-bottom-nav/index.tsx
+++ b/web/src/components/mobile-bottom-nav/index.tsx
@@ -1,0 +1,52 @@
+import { FileTextIcon, TicketIcon, MenuIcon, SearchIcon } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useSidebar } from '@/components/ui/sidebar';
+import { ROUTES } from '@/types/routes.type';
+import { cn } from '@/lib/utils';
+
+const NAV_ITEMS = [
+  { label: 'Jugadas', route: ROUTES.MAKE_PLAYS, icon: FileTextIcon },
+  { label: 'Aciertos', route: ROUTES.PLAYS_AND_HITS, icon: TicketIcon },
+  { label: 'Ticket', route: ROUTES.TERMINAL_TICKET, icon: SearchIcon },
+  { label: 'Resultados', route: ROUTES.RESULTS, icon: FileTextIcon },
+] as const;
+
+const MobileBottomNav = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-card border-t border-border pb-[env(safe-area-inset-bottom)]">
+      <div className="flex items-stretch h-14">
+        {NAV_ITEMS.map(({ label, route, icon: Icon }) => {
+          const isActive = location.pathname === route;
+          return (
+            <button
+              key={route}
+              onClick={() => navigate(route)}
+              className={cn(
+                'flex flex-col items-center justify-center flex-1 gap-0.5 text-xs transition-colors',
+                isActive
+                  ? 'text-primary border-t-2 border-primary -mt-px'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <Icon className="w-5 h-5" />
+              <span>{label}</span>
+            </button>
+          );
+        })}
+        <button
+          onClick={toggleSidebar}
+          className="flex flex-col items-center justify-center flex-1 gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <MenuIcon className="w-5 h-5" />
+          <span>Más</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MobileBottomNav;

--- a/web/src/components/modals/PrintDailySummaryModal.tsx
+++ b/web/src/components/modals/PrintDailySummaryModal.tsx
@@ -102,6 +102,7 @@ const PrintDailySummaryModal = ({
           <SelectDayToSearch
             selectedDay={dateFrom}
             onDayChange={(d) => d && setDateFrom(d)}
+            toDate={dayjs().toDate()}
             className="w-full"
           />
         </div>
@@ -110,6 +111,7 @@ const PrintDailySummaryModal = ({
           <SelectDayToSearch
             selectedDay={dateTo}
             onDayChange={(d) => d && setDateTo(d)}
+            toDate={dayjs().toDate()}
             className="w-full"
           />
         </div>

--- a/web/src/components/modals/PrintSubtotalsModal.tsx
+++ b/web/src/components/modals/PrintSubtotalsModal.tsx
@@ -148,6 +148,7 @@ const PrintSubtotalsModal = ({
             <SelectDayToSearch
               selectedDay={date}
               onDayChange={(d) => d && setDate(d)}
+              toDate={dayjs().toDate()}
               className="w-full"
             />
           </div>
@@ -160,6 +161,7 @@ const PrintSubtotalsModal = ({
               <SelectDayToSearch
                 selectedDay={dateFrom}
                 onDayChange={(d) => d && setDateFrom(d)}
+                toDate={dayjs().toDate()}
                 className="w-full"
               />
             </div>
@@ -168,6 +170,7 @@ const PrintSubtotalsModal = ({
               <SelectDayToSearch
                 selectedDay={dateTo}
                 onDayChange={(d) => d && setDateTo(d)}
+                toDate={dayjs().toDate()}
                 className="w-full"
               />
             </div>

--- a/web/src/components/modals/PrintTotalsModal.tsx
+++ b/web/src/components/modals/PrintTotalsModal.tsx
@@ -204,6 +204,7 @@ const PrintTotalsModal = ({
               <SelectDayToSearch
                 selectedDay={date}
                 onDayChange={(d) => d && setDate(d)}
+                toDate={dayjs().toDate()}
                 className="w-full"
               />
             </div>
@@ -276,6 +277,7 @@ const PrintTotalsModal = ({
               <SelectDayToSearch
                 selectedDay={dateFrom}
                 onDayChange={(d) => d && setDateFrom(d)}
+                toDate={dayjs().toDate()}
                 className="w-full"
               />
             </div>
@@ -284,6 +286,7 @@ const PrintTotalsModal = ({
               <SelectDayToSearch
                 selectedDay={dateTo}
                 onDayChange={(d) => d && setDateTo(d)}
+                toDate={dayjs().toDate()}
                 className="w-full"
               />
             </div>

--- a/web/src/components/wrapper/PageWrapper.tsx
+++ b/web/src/components/wrapper/PageWrapper.tsx
@@ -4,7 +4,7 @@ import { FlexCol } from '../flex';
 export const PageWrapper = ({children}:{children: ReactNode[]}) => {
   return (
     <FlexCol
-      className={'h-full w-full max-w-full overflow-y-auto overflow-x-hidden gap-1 2xl:gap-2'}
+      className={'h-full w-full max-w-full overflow-y-auto overflow-x-hidden gap-2 sm:gap-3 2xl:gap-4'}
     >
       {children}
     </FlexCol>

--- a/web/src/constants/SidebarMenu.tsx
+++ b/web/src/constants/SidebarMenu.tsx
@@ -52,14 +52,14 @@ export const MENU_ITEMS: MENU_ITEM[] = [
   },
   {
     id: 'LoteriesAndSchedules',
-    name: 'Qunielas y Turnos',
+    name: 'Quinielas y Turnos',
     route: ROUTES.UPCOMING_LOTTERIES,
     icon: <UserIcon size={20} />,
     roles: ALL_EXCEPT_CASHIER,
     children: [
       {
         id: 'UpcomingLotteries',
-        name: 'Qunielas a jugarse',
+        name: 'Quinielas a jugarse',
         route: ROUTES.UPCOMING_LOTTERIES,
         icon: <FileTextIcon size={20} />,
       },

--- a/web/src/features/current-account/index.tsx
+++ b/web/src/features/current-account/index.tsx
@@ -132,7 +132,7 @@ const CurrentAccountContent = () => {
     <PageWrapper>
       <HeaderSection title={'Cuenta Corriente'}>
         <IsRoleCashier role={role}>
-          <Box className={'grid grid-cols-2 gap-4'}>
+          <Box className={'grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4'}>
             <Button onClick={handlePrintDiaryLiquidation} disabled={printing}>
               Exportar Diario
             </Button>

--- a/web/src/features/groups/index.tsx
+++ b/web/src/features/groups/index.tsx
@@ -218,15 +218,15 @@ const UserGroupsContent = () => {
       </HeaderSection>
 
       <FlexCol className={'py-[36px]'}>
-        <Box className={'grid grid-cols-2 gap-8'}>
+        <Box className={'grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8'}>
           <FlexCol>
             <HeaderTitleSection
               title={'Grupos'}
               icon={<Users2Icon size="24px" />}
               className={'!mb-[36px]'}
             />
-            <Flex className={'border border-dark-lighter rounded-lg overflow-hidden w-full'}>
-              <Table>
+            <div className="border border-dark-lighter rounded-lg overflow-x-auto w-full">
+              <Table className="min-w-[300px]">
                 <TableHeader className="bg-dark-light">
                   <TableRow>
                     <TableHead className="text-white">Nombre</TableHead>
@@ -289,7 +289,7 @@ const UserGroupsContent = () => {
                   )}
                 </TableBody>
               </Table>
-            </Flex>
+            </div>
           </FlexCol>
 
           <FlexCol>
@@ -316,8 +316,8 @@ const UserGroupsContent = () => {
                 <p className="text-sm text-muted-foreground">
                   Grupo: <strong>{selectedGroup.name}</strong> - Los usuarios asignados solo verán datos de este grupo.
                 </p>
-                <Flex className={'border border-dark-lighter rounded-lg overflow-hidden w-full'}>
-                  <Table>
+                <div className="border border-dark-lighter rounded-lg overflow-x-auto w-full">
+                  <Table className="min-w-[300px]">
                     <TableHeader className="bg-dark-light">
                       <TableRow>
                         <TableHead className="text-white">Número</TableHead>
@@ -363,7 +363,7 @@ const UserGroupsContent = () => {
                       )}
                     </TableBody>
                   </Table>
-                </Flex>
+                </div>
               </div>
             ) : (
               <div className="border border-dark-lighter rounded-lg p-4 text-center text-muted-foreground min-h-[160px] flex items-center justify-center">

--- a/web/src/features/make-plays/fill-out-a-ticket.tsx
+++ b/web/src/features/make-plays/fill-out-a-ticket.tsx
@@ -220,7 +220,7 @@ const FillOutATicket = () => {
 
   return (
     <FlexCol className={'h-fit w-full max-w-full'}>
-      <Flex className={'flex-col-reverse sm:flex-row gap-1 sm:gap-2 lg:gap-3 sm:items-stretch w-full'}>
+      <Flex className={'flex-col sm:flex-row gap-1 sm:gap-2 lg:gap-3 sm:items-stretch w-full'}>
         <Flex className={'flex-1 sm:max-w-[280px] md:max-w-[260px] lg:max-w-[320px] w-full'}>
           <form className={'w-full'}>
             <FlexCol className={'space-y-1 sm:space-y-3 lg:space-y-1 h-full border p-2 sm:p-3 lg:p-1.5 bg-card rounded-[--rounded-form] justify-between'}>

--- a/web/src/features/make-plays/results-overview.tsx
+++ b/web/src/features/make-plays/results-overview.tsx
@@ -24,7 +24,7 @@ const ResultsOverview = () => {
   return (
     <Flex
       className={
-        'flex-col sm:flex-row gap-2 sm:gap-4 p-1 1440:p-2 items-center  sticky bottom-0 bg-background z-10'
+        'flex-col sm:flex-row gap-2 sm:gap-4 p-1 1440:p-2 items-center sticky bottom-0 bg-background z-10 border-t border-border shadow-[0_-4px_12px_rgba(0,0,0,0.3)]'
       }
     >
       <Flex

--- a/web/src/features/organizations/index.tsx
+++ b/web/src/features/organizations/index.tsx
@@ -181,12 +181,12 @@ const OrganizationsContent = () => {
         )}
 
         {!isLoading && !error && organizations && organizations.length > 0 && (
-          <div className="rounded-md border">
-            <table className="w-full">
+          <div className="rounded-md border overflow-x-auto w-full">
+            <table className="w-full min-w-[500px]">
               <thead>
                 <tr className="border-b bg-muted/50">
                   <th className="h-12 px-4 text-left align-middle font-medium">Nombre</th>
-                  <th className="h-12 px-4 text-left align-middle font-medium">ID</th>
+                  <th className="h-12 px-4 text-left align-middle font-medium hidden sm:table-cell">ID</th>
                   <th className="h-12 px-4 text-right align-middle font-medium">Acciones</th>
                 </tr>
               </thead>
@@ -194,37 +194,37 @@ const OrganizationsContent = () => {
                 {organizations.map((org) => (
                   <tr key={org.organization_id} className="border-b hover:bg-muted/50">
                     <td className="p-4 align-middle font-medium">{org.name}</td>
-                    <td className="p-4 align-middle text-sm text-muted-foreground">
-                      {org.organization_id}
+                    <td className="p-4 align-middle text-sm text-muted-foreground hidden sm:table-cell">
+                      <span title={org.organization_id}>{org.organization_id.slice(0, 8)}...</span>
                     </td>
                     <td className="p-4 align-middle text-right">
-                      <div className="flex justify-end gap-2">
+                      <div className="flex justify-end gap-1 sm:gap-2">
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleEdit(org)}
-                          className="gap-2"
+                          className="gap-1 sm:gap-2"
                         >
                           <Pencil className="h-4 w-4" />
-                          Editar
+                          <span className="hidden sm:inline">Editar</span>
                         </Button>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleResetPassword(org)}
-                          className="gap-2 text-yellow-600 hover:text-yellow-500"
+                          className="gap-1 sm:gap-2 text-yellow-600 hover:text-yellow-500"
                         >
                           <KeyRound className="h-4 w-4" />
-                          Resetear Contraseña
+                          <span className="hidden sm:inline">Resetear Contraseña</span>
                         </Button>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleDelete(org)}
-                          className="gap-2 text-destructive hover:text-destructive"
+                          className="gap-1 sm:gap-2 text-destructive hover:text-destructive"
                         >
                           <Trash2 className="h-4 w-4" />
-                          Eliminar
+                          <span className="hidden sm:inline">Eliminar</span>
                         </Button>
                       </div>
                     </td>

--- a/web/src/features/upcoming-lotteries/index.tsx
+++ b/web/src/features/upcoming-lotteries/index.tsx
@@ -86,6 +86,7 @@ const hasUnsavedChanges = (current: DayMap, server: DayMap): boolean => {
 const UpcomingLotteriesContent = () => {
   const { role } = useAuth();
   const canEdit = role !== USER_TYPE.ADMIN;
+  const is1440 = useMediaQuery('(min-width: 1440px)');
 
   const [savedData, setSavedData] = useState<DayMap>({});
   const [serverData, setServerData] = useState<DayMap>({});
@@ -196,22 +197,22 @@ const UpcomingLotteriesContent = () => {
           <div className="rounded-xl p-4 space-y-4">
             <div className="bg-dark-light rounded-xl space-y-6">
               <div className="space-y-6">
-                <div className="border bg-card rounded-lg px-4 py-4 1440:py-8">
+                <div className="border bg-card rounded-lg px-3 py-3 sm:px-4 sm:py-4 1440:py-8">
                   <HeaderTitleSection
                     title={'Día'}
-                    icon={<Calendar size={useMediaQuery('(min-width: 1440px)') ? '24px' : '16px'} />}
-                    size={useMediaQuery('(min-width: 1440px)') ? 'lg' : 'sm'}
+                    icon={<Calendar size={is1440 ? '24px' : '16px'} />}
+                    size={is1440 ? 'lg' : 'sm'}
                     className={'!mb-[36px]'}
                     />
 
                   <DayRadioList selectedDay={selectedDay} handleDay={handleDay} />
                 </div>
 
-                <div className="border bg-card rounded-lg px-4 py-4 1440:py-8">
+                <div className="border bg-card rounded-lg px-3 py-3 sm:px-4 sm:py-4 1440:py-8">
                   <HeaderTitleSection
                     title={'Turno Seleccionado'}
-                    icon={<Clock size={useMediaQuery('(min-width: 1440px)') ? '24px' : '16px'} />}
-                    size={useMediaQuery('(min-width: 1440px)') ? 'lg' : 'sm'}
+                    icon={<Clock size={is1440 ? '24px' : '16px'} />}
+                    size={is1440 ? 'lg' : 'sm'}
                     className={'!mb-[36px]'}
                     />
 
@@ -221,11 +222,11 @@ const UpcomingLotteriesContent = () => {
                     />
                 </div>
 
-                <div className="border bg-card rounded-lg px-4 py-4 1440:py-8">
+                <div className="border bg-card rounded-lg px-3 py-3 sm:px-4 sm:py-4 1440:py-8">
                   <HeaderTitleSection
                     title={'Quinielas'}
-                    icon={<Ticket size={useMediaQuery('(min-width: 1440px)') ? '24px' : '16px'} />}
-                    size={useMediaQuery('(min-width: 1440px)') ? 'lg' : 'sm'}
+                    icon={<Ticket size={is1440 ? '24px' : '16px'} />}
+                    size={is1440 ? 'lg' : 'sm'}
                     className={'!mb-[36px]'}
                     />
 
@@ -245,7 +246,7 @@ const UpcomingLotteriesContent = () => {
                     <Button
                       type="submit"
                       variant={'default'}
-                      className=" w-[200px]   hover:bg-dark text-white"
+                      className="w-full sm:w-[200px] hover:bg-dark text-white"
                       onClick={handleSave}
                       disabled={isPendingSave}
                       >

--- a/web/src/features/user-list/user-table.tsx
+++ b/web/src/features/user-list/user-table.tsx
@@ -58,9 +58,9 @@ const UsersTable = () => {
   if (error) return <div>Error al obtener usuarios</div>;
 
   return (
-    <div className="border border-dark-lighter rounded-lg overflow-hidden w-full h-full max-h-[calc(100vh-280px)] flex flex-col">
-      <div className="overflow-y-auto flex-1">
-        <table className="w-full caption-bottom text-sm">
+    <div className="border border-dark-lighter rounded-lg w-full h-full max-h-[calc(100vh-280px)] flex flex-col overflow-hidden">
+      <div className="overflow-y-auto overflow-x-auto flex-1">
+        <table className="w-full caption-bottom text-sm min-w-[700px]">
           <thead className="bg-dark-light sticky top-0 z-10 [&_tr]:border-b">
             <TableRow>
               <TableHead className="text-white bg-dark-light">Numero</TableHead>

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -80,8 +80,8 @@
   --sidebar-ring: oklch(0.541 0.281 293.009);
   --text-muted: oklch(0.967 0.001 286.375);
   --text-secondary: #41dbc3;
-  --bg-accen: #000;
-  --border-top: 16px 16px 0 0;
+  --bg-accent: #000;
+  --rounded-top: 16px 16px 0 0;
   --bg-content: hsl(231 50% 5% / 1);
   --rounded-form: 16px;
 }


### PR DESCRIPTION
- Add mobile bottom tab bar (md:hidden) with 4 routes + sidebar toggle
- Add max-width 1440px container on main content area
- Footer: time and date inline on mobile, smaller font
- HeaderSection: title visible on mobile, bg/z-index for sticky
- Calendars: weekStartsOn Sunday, toDate=today on all print modals
- Groups/Organizations/UserList: overflow-x-auto on tables
- Groups grid: responsive (1 col mobile, 2 col desktop)
- Organizations: UUID truncated, action labels hidden on mobile
- CurrentAccount buttons: single column on mobile
- UpcomingLotteries: responsive save button, hoisted useMediaQuery
- MakePlays: form first on mobile (fix flex-col-reverse), results-overview shadow
- IconButton: increased mobile touch target h-7→h-10
- Fix CSS variable typos: --bg-accen, --border-top
- Fix sidebar menu typos: Qunielas→Quinielas (x2)