### PR TITLE
fix(web): footer hidden behind fixed bottom nav on mobile

### DIFF
--- a/web/src/components/layout/index.tsx
+++ b/web/src/components/layout/index.tsx
@@ -32,7 +32,7 @@ const Layout = () => {
           <Header setIsOpen={toggleSidebar} />
 
           <main
-            className="flex flex-1 w-full max-w-full mx-auto min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-3 py-1 sm:px-3 xl:px-4 2xl:px-5 2xl:py-2 justify-center pb-16 md:pb-0"
+            className="flex flex-1 w-full max-w-full mx-auto min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-3 py-1 sm:px-3 xl:px-4 2xl:px-5 2xl:py-2 justify-center"
             style={{
               scrollbarWidth: 'thin',
               scrollbarColor: '#666 transparent',

--- a/web/src/components/mobile-bottom-nav/index.tsx
+++ b/web/src/components/mobile-bottom-nav/index.tsx
@@ -17,7 +17,7 @@ const MobileBottomNav = () => {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-card border-t border-border pb-[env(safe-area-inset-bottom)]">
+    <div className="md:hidden bg-card border-t border-border pb-[env(safe-area-inset-bottom)]">
       <div className="flex items-stretch h-14">
         {NAV_ITEMS.map(({ label, route, icon: Icon }) => {
           const isActive = location.pathname === route;


### PR DESCRIPTION
Bottom nav moved to normal flow (not fixed) so footer stays visible. Removed pb-16 workaround from main content area.