### PR TITLE
fix(web): ticket search breaks with new YYYYMMDDHHmmssSSS-N format

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-21
+
+#### Ticket search by number — compatibility with new format
+- **`web/src/hooks/fetchs/tickets/useGetTicketByNumber.ts`**: Changed `length === 17` to `length >= 17` so search works with new ticket format `YYYYMMDDHHmmssSSS-N` (includes cashier number suffix).
+- **`web/src/features/terminal-ticket/form-header-filter.tsx`**: Changed ticket number input `type="number"` → `type="text"` so the dash in the new format is accepted. Cashier users who type only the base number (without `-N` suffix) get it auto-appended from their own `user.number`.
+- **`web/src/components/modals/repeat-ticket-modal.tsx`**: Same fixes — `type="text"` input, and cashier auto-append of `-{user.number}` suffix when missing.
+
 ### Added - 2026-04-20
 
 #### UX/UI General — Mobile responsiveness & layout improvements

--- a/web/src/components/modals/repeat-ticket-modal.tsx
+++ b/web/src/components/modals/repeat-ticket-modal.tsx
@@ -50,7 +50,11 @@ const RepeatTicketModal = ({ isOpen, title, onClose, handleRecreateBet }: BasicM
   const { data: schedules } = useSchedules();
   const { data: scheduleLottery } = useScheduleLottery();
   const { data: lotteries } = useLotteries({ all: true });
-  const { data } = getTicketByNumber(ticketNumber);
+  const queryTicketNumber =
+    isCashier && ticketNumber && !ticketNumber.includes('-') && user?.number != null
+      ? `${ticketNumber}-${user.number}`
+      : ticketNumber;
+  const { data } = getTicketByNumber(queryTicketNumber || null);
 
   const handleSetBets = () => {
     handleRecreateBet(selectedBets);
@@ -275,7 +279,7 @@ useEffect(() => {
               Ticket N°:
             </Text>
             <Input
-              type="number"
+              type="text"
               value={ticketNumber}
               onChange={(e) => {
                 setTicketNumber(e.target.value);

--- a/web/src/features/terminal-ticket/form-header-filter.tsx
+++ b/web/src/features/terminal-ticket/form-header-filter.tsx
@@ -25,7 +25,7 @@ import { USER_TYPE } from '@helper/types/user.type';
 import { useTerminalTicket } from './provider/TerminalTicketProvider';
 
 const FormHeaderFilter = () => {
-  const { role, organizationId } = useAuth();
+  const { role, organizationId, user } = useAuth();
   const { cashier_id, group_id, setDate, toggleCashier, setCashierId, setGroupId, setTicketNumber, resetTicketNumber, setFilter } = useTerminalTicket();
   const { data: allCashiers } = useUsers(role);
   const { data: groups } = useGroups(organizationId, role);
@@ -34,7 +34,12 @@ const FormHeaderFilter = () => {
   const [inputValue, setInputValue] = useState('');
 
   const handleSearch = () => {
-    setTicketNumber(inputValue.trim());
+    const trimmed = inputValue.trim();
+    const normalized =
+      role === USER_TYPE.CASHIER && !trimmed.includes('-') && user?.number != null
+        ? `${trimmed}-${user.number}`
+        : trimmed;
+    setTicketNumber(normalized);
     setInputValue('');
   };
 
@@ -140,8 +145,7 @@ const FormHeaderFilter = () => {
       <Fieldset legend="Buscar por número de Ticket:" className="w-full  flex gap-3">
         <FlexCol className="w-full gap-4">
           <Input
-            type="number"
-            inputMode="numeric"
+            type="text"
             className=""
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}

--- a/web/src/hooks/fetchs/tickets/useGetTicketByNumber.ts
+++ b/web/src/hooks/fetchs/tickets/useGetTicketByNumber.ts
@@ -17,5 +17,5 @@ export const getTicketByNumber = (ticket_number: string | null) =>
   useQuery({
     queryKey: ['ticket_number', ticket_number],
     queryFn: () => fetchTicketsByNumber(ticket_number),
-    enabled: !!ticket_number && ticket_number?.length === 17,
+    enabled: !!ticket_number && ticket_number?.length >= 17,
   });


### PR DESCRIPTION
- Allow length >= 17 in useGetTicketByNumber (was === 17, rejecting new format)
- Change ticket number inputs from type=number to type=text (dash not allowed in number inputs)
- Cashier users who omit the -N suffix get it auto-appended from their own user.number