### PR TITLE
fix(web): bets not loading when ticket date differs from URL date

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the Web workspace are documented in this file.
 
 ### Fixed - 2026-04-21
 
+#### Ticket bets not loading when date in URL differs from ticket date
+- **`web/src/hooks/fetchs/plays/useInfiniteBetsByTicketNumber.ts`**: Derive effective `date` from first 8 chars of `ticket_number` (`YYYYMMDD`) instead of using the URL date param. Fixes case where user views a ticket from a previous day while the URL date is today. Also relaxed `enabled` to only require `ticket_number` (date always derivable from it).
+
 #### Ticket search by number — compatibility with new format
 - **`web/src/hooks/fetchs/tickets/useGetTicketByNumber.ts`**: Changed `length === 17` to `length >= 17` so search works with new ticket format `YYYYMMDDHHmmssSSS-N` (includes cashier number suffix).
 - **`web/src/features/terminal-ticket/form-header-filter.tsx`**: Changed ticket number input `type="number"` → `type="text"` so the dash in the new format is accepted. Cashier users who type only the base number (without `-N` suffix) get it auto-appended from their own `user.number`.

--- a/web/src/hooks/fetchs/plays/useInfiniteBetsByTicketNumber.ts
+++ b/web/src/hooks/fetchs/plays/useInfiniteBetsByTicketNumber.ts
@@ -17,12 +17,16 @@ export interface FetchInfiniteBetsByTicketNumberProps {
   limit?: number;
 }
 
+function dateFromTicketNumber(ticket_number: string): string {
+  const raw = ticket_number.slice(0, 8);
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+}
+
 export async function fetchPaginatedBetsByTicketNumber(
   props: FetchInfiniteBetsByTicketNumberProps,
   pageParam: number = 1
 ): Promise<IPaginatedBetsResponse<IBetEntityFront>> {
   const {
-    date,
     schedule_id,
     lottery_id,
     cashier_id,
@@ -33,6 +37,8 @@ export async function fetchPaginatedBetsByTicketNumber(
     ticket_number,
     limit = 150,
   } = props;
+
+  const date = ticket_number ? dateFromTicketNumber(ticket_number) : props.date;
 
   if (!date || !ticket_number) {
     return {
@@ -96,7 +102,7 @@ export const useInfiniteBetsByTicketNumber = (props: FetchInfiniteBetsByTicketNu
     getNextPageParam: (lastPage) => {
       return lastPage.pagination.hasMore ? lastPage.pagination.currentPage + 1 : undefined;
     },
-    enabled: Boolean(props.date && props.ticket_number),
+    enabled: Boolean(props.ticket_number),
     initialPageParam: 1,
   });
 };


### PR DESCRIPTION
useInfiniteBetsByTicketNumber now derives date from the first 8 chars of ticket_number (YYYYMMDD) instead of using the URL date param. Fixes blank play table when viewing a ticket from a previous day.