### PR TITLE
feat(current-account): add day/range mode to Resumen Cuenta Corriente…

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to the Web workspace are documented in this file.
 
 ### Changed - 2026-04-21
 
+#### Resumen Cuenta Corriente — agregar modo día/rango
+
+- **`web/src/components/modals/PrintDailySummaryModal.tsx`**: Agregado selector Día/Rango. Modo día + grupo → PDF por pasadores. Modo rango (con o sin grupo) → PDF por fecha. Antes con grupo seleccionado solo mostraba un único datepicker.
+
 #### Exportar Subtotales — porcentaje capitalista solo en modo rango
 
 - **`web/src/components/modals/PrintSubtotalsModal.tsx`**: Porcentaje capitalista movido dentro del bloque `mode === 'range'`. Modo día solo muestra fecha y gastos; modo rango solo muestra rango de fechas y porcentaje. Removido `percentage` del llamado a `printSubtotalsDayTicket`.

--- a/web/src/components/modals/PrintDailySummaryModal.tsx
+++ b/web/src/components/modals/PrintDailySummaryModal.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import Modal from './custom-modal';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Select,
   SelectContent,
@@ -39,6 +40,8 @@ const PrintDailySummaryModal = ({
   const { organizationId, role } = useAuth();
   const { data: groups } = useGroups(organizationId, role);
 
+  const [mode, setMode] = useState<'day' | 'range'>('day');
+  const [date, setDate] = useState<string>(initialDate ?? dayjs().format('YYYY-MM-DD'));
   const [dateFrom, setDateFrom] = useState<string>(
     initialDate ?? dayjs().startOf('week').format('YYYY-MM-DD')
   );
@@ -63,20 +66,22 @@ const PrintDailySummaryModal = ({
   const handlePrint = async () => {
     try {
       setPrinting(true);
-      if (effectiveGroupId && selectedGroup) {
-        const data = await fetchCurrentAccount(dateTo, effectiveGroupId);
+      if (mode === 'day' && effectiveGroupId && selectedGroup) {
+        const data = await fetchCurrentAccount(date, effectiveGroupId);
         if (!data.length) {
           toast.error('Sin datos para esa fecha.');
           return;
         }
-        await downloadCurrentAccountGroupSummaryPDF({ date: dateTo, data, groupName: selectedGroup.name });
+        await downloadCurrentAccountGroupSummaryPDF({ date, data, groupName: selectedGroup.name });
       } else {
-        const data = await fetchCurrentAccountDailySummary(dateFrom, dateTo, effectiveGroupId);
+        const from = mode === 'day' ? date : dateFrom;
+        const to = mode === 'day' ? date : dateTo;
+        const data = await fetchCurrentAccountDailySummary(from, to, effectiveGroupId);
         if (!data.length) {
           toast.error('Sin datos para ese período.');
           return;
         }
-        await downloadCurrentAccountDailySummaryPDF({ date_from: dateFrom, date_to: dateTo, data, groupName: selectedGroup?.name });
+        await downloadCurrentAccountDailySummaryPDF({ date_from: from, date_to: to, data, groupName: selectedGroup?.name });
       }
       toast.success('PDF generado.');
       onClose();
@@ -109,17 +114,37 @@ const PrintDailySummaryModal = ({
           </div>
         )}
 
-        {effectiveGroupId ? (
+        <div className="space-y-2">
+          <Label>Tipo de reporte</Label>
+          <RadioGroup
+            value={mode}
+            onValueChange={(v) => setMode(v as 'day' | 'range')}
+            className="flex gap-4"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="day" id="sum-mode-day" />
+              <Label htmlFor="sum-mode-day" className="cursor-pointer">Día</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="range" id="sum-mode-range" />
+              <Label htmlFor="sum-mode-range" className="cursor-pointer">Rango de fechas</Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {mode === 'day' && (
           <div className="space-y-1">
             <Label>Fecha</Label>
             <SelectDayToSearch
-              selectedDay={dateTo}
-              onDayChange={(d) => d && setDateTo(d)}
+              selectedDay={date}
+              onDayChange={(d) => d && setDate(d)}
               toDate={dayjs().toDate()}
               className="w-full"
             />
           </div>
-        ) : (
+        )}
+
+        {mode === 'range' && (
           <>
             <div className="space-y-1">
               <Label>Desde</Label>


### PR DESCRIPTION
… modal

Day + group → per-cashier PDF; range (with or without group) → per-date PDF filtered by group.