### PR TITLE
fix(pdf): use afterprint event instead of setTimeout for iframe cleanup

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-23
+
+#### Exportar Diario — diálogo de impresión se cerraba al cambiar configuración
+
+- **`web/src/functions/pdf-shared.ts`**: `openPDFPrintDialog` usaba `setTimeout` de 1000ms para limpiar el iframe, lo que eliminaba el iframe (y cerraba el diálogo) mientras el usuario todavía interactuaba con la configuración de impresión. Reemplazado por el evento `afterprint` que dispara solo cuando el usuario cierra el diálogo.
+
 ### Added - 2026-04-21
 
 #### Cuenta Corriente — mejoras de UI y exportaciones

--- a/web/src/functions/makeTicket.ts
+++ b/web/src/functions/makeTicket.ts
@@ -206,6 +206,12 @@ export function printPdfBlob(blob: Blob) {
   document.body.appendChild(iframe);
   iframe.onload = () => {
     iframe.contentWindow?.focus();
+    const cleanup = () => {
+      if (document.body.contains(iframe)) document.body.removeChild(iframe);
+      URL.revokeObjectURL(url);
+      iframe.contentWindow?.removeEventListener('afterprint', cleanup);
+    };
+    iframe.contentWindow?.addEventListener('afterprint', cleanup);
     iframe.contentWindow?.print();
   };
 }

--- a/web/src/functions/pdf-shared.ts
+++ b/web/src/functions/pdf-shared.ts
@@ -94,12 +94,14 @@ export function openPDFPrintDialog(doc: any, filename: string) {
     const prev = document.title;
     document.title = filename;
     iframe.contentWindow?.focus();
-    iframe.contentWindow?.print();
-    setTimeout(() => {
+    const cleanup = () => {
       document.title = prev;
-      document.body.removeChild(iframe);
+      if (document.body.contains(iframe)) document.body.removeChild(iframe);
       URL.revokeObjectURL(url);
-    }, 1000);
+      iframe.contentWindow?.removeEventListener('afterprint', cleanup);
+    };
+    iframe.contentWindow?.addEventListener('afterprint', cleanup);
+    iframe.contentWindow?.print();
   };
 }
 


### PR DESCRIPTION
Print dialog was closing prematurely when user changed print settings. setTimeout(1000) removed the iframe while dialog was still open. Also fixes memory leak in printPdfBlob (no cleanup at all previously).