### PR TITLE
feat(plays-and-hits): add min amount filter input for grouped bets

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-23
+
+#### Jugadas y Aciertos — filtro cota mínima en modo agrupado
+
+- **`web/src/features/plays-and-hits/min-amount-input.tsx`**: Nuevo input numérico que aparece solo cuando `grouped=true`. Al aplicar (blur o Enter) escribe `min_amount` en los URL params; si el valor es 0 o vacío lo elimina. La tabla ya leía ese param y lo enviaba al RPC (`HAVING SUM >= p_min_amount`).
+- **`web/src/features/plays-and-hits/index.tsx`**: Renderiza `MinAmountInput` junto a `PlayAndHitsToggleSelect` y `PrintGroupedBetsButton`.
+- **`web/src/features/plays-and-hits/play-and-hits-toggle-select.tsx`**: Al desactivar modo agrupado elimina `min_amount` de los URL params para evitar que persista en modo individual.
+
 ### Fixed - 2026-04-23
 
 #### Exportar Diario — diálogo de impresión se cerraba al cambiar configuración

--- a/web/src/features/plays-and-hits/index.tsx
+++ b/web/src/features/plays-and-hits/index.tsx
@@ -6,6 +6,7 @@ import SelectBetType from './select-bet-type';
 import PlayAndHitsToggleSelect from './play-and-hits-toggle-select';
 import PlayAndHitsSelect from './play-and-hits-select';
 import PrintGroupedBetsButton from './print-grouped-bets-button';
+import MinAmountInput from './min-amount-input';
 import { PageWrapper } from '@/components/wrapper/PageWrapper';
 import { useState, useCallback } from 'react';
 
@@ -25,6 +26,7 @@ const PlaysAndHitsContent = () => {
         <Flex className="items-center gap-2">
           <PlayAndHitsToggleSelect />
           <PrintGroupedBetsButton />
+          <MinAmountInput />
         </Flex>
         <Flex className="flex-col sm:flex-row w-full">
           <SelectBetType />

--- a/web/src/features/plays-and-hits/min-amount-input.tsx
+++ b/web/src/features/plays-and-hits/min-amount-input.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Input } from '@/components/ui/input';
+
+const MinAmountInput = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const grouped = searchParams.get('grouped') === 'true';
+  const [value, setValue] = useState(searchParams.get('min_amount') ?? '');
+
+  if (!grouped) return null;
+
+  const apply = () => {
+    const params = new URLSearchParams(searchParams);
+    const num = parseFloat(value);
+    if (!num || num <= 0) params.delete('min_amount');
+    else params.set('min_amount', String(num));
+    setSearchParams(params);
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">Monto mínimo</span>
+      <Input
+        type="number"
+        min={0}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={apply}
+        onKeyDown={(e) => e.key === 'Enter' && apply()}
+        placeholder="0"
+        className="w-[120px] h-8"
+      />
+    </div>
+  );
+};
+
+export default MinAmountInput;

--- a/web/src/features/plays-and-hits/play-and-hits-toggle-select.tsx
+++ b/web/src/features/plays-and-hits/play-and-hits-toggle-select.tsx
@@ -25,6 +25,7 @@ const PlayAndHitsToggleSelect = () => {
   const handleChangeGrouped = () => {
     const newParams = new URLSearchParams(searchParams);
     newParams.set('grouped', (!grouped).toString());
+    if (grouped) newParams.delete('min_amount');
     setSearchParams(newParams);
   };
   return (


### PR DESCRIPTION
Adds a numeric input that appears only in grouped mode to filter bets with a total amount >= the entered value. Clears the param when toggling back to individual mode.