### PR TITLE
fix(archive): resolve ambiguous overload and statement timeout

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-23
+
+#### Archive RPC — statement timeout + single-batch loop
+- **`api/src/archive/service/archive.service.ts`**: `archiveOldData` now loops per date until `bets_remaining + tickets_remaining = 0`, passing `p_batch_size: 500` per call. Previous code called the RPC once per date with default batch 5000, which exceeded PostgREST's ~8 s statement timeout on large days.
+
+#### Archive RPC — ambiguous function overload
+- **`api/supabase/migrations/20260423061747_drop_archive_data_by_date_single_param.sql`**: Drops `archive_data_by_date(DATE)` left over from migration `20260415`. Migration `20260422` added a two-param overload `(DATE, INTEGER DEFAULT 5000)` with a different signature so Postgres kept both. RPC calls with only `p_date` got "could not choose best candidate function" error. Removing the old overload leaves only the batch-size version.
+
 ### Added - 2026-04-21
 
 #### Org Expenses — soporte de grupo

--- a/api/src/archive/service/archive.service.ts
+++ b/api/src/archive/service/archive.service.ts
@@ -79,14 +79,32 @@ export class ArchiveService {
 
     for (const date of datesToArchive) {
       try {
-        const { data, error } = await supabase.rpc('archive_data_by_date', { p_date: date });
+        let totalBets = 0;
+        let totalTickets = 0;
 
-        if (error) throw new Error(error.message);
+        // Loop until both bets and tickets for this date are fully archived.
+        // Each call processes one batch (p_batch_size rows) to stay within
+        // PostgREST's statement timeout (~8 s). The function signals completion
+        // when bets_remaining + tickets_remaining = 0.
+        while (true) {
+          const { data, error } = await supabase.rpc('archive_data_by_date', {
+            p_date: date,
+            p_batch_size: 500,
+          });
+
+          if (error) throw new Error(error.message);
+
+          totalBets += data.bets_archived as number;
+          totalTickets += data.tickets_archived as number;
+
+          const remaining = (data.bets_remaining as number) + (data.tickets_remaining as number);
+          if (remaining === 0) break;
+        }
 
         const dayResult: IArchiveDayResult = {
           date,
-          bets_archived: data.bets_archived,
-          tickets_archived: data.tickets_archived,
+          bets_archived: totalBets,
+          tickets_archived: totalTickets,
           success: true,
         };
 

--- a/api/supabase/migrations/20260423061747_drop_archive_data_by_date_single_param.sql
+++ b/api/supabase/migrations/20260423061747_drop_archive_data_by_date_single_param.sql
@@ -1,0 +1,7 @@
+-- Drop the single-param overload left over from 20260415080624_archive_by_date.sql.
+-- Migration 20260422000000 added archive_data_by_date(DATE, INTEGER DEFAULT 5000),
+-- which is a different signature so Postgres kept both. PostgREST/RPC calls that pass
+-- only p_date now get "could not choose best candidate function" because both match.
+-- The two-param version (with batch_size) is the current implementation; remove the old one.
+
+DROP FUNCTION IF EXISTS archive_data_by_date(DATE);


### PR DESCRIPTION
Drop archive_data_by_date(DATE) left from 20260415 — adding a two-param overload in 20260422 created two matching candidates, causing PostgREST "could not choose best candidate function" errors.

Loop per date in TS until bets_remaining + tickets_remaining = 0, passing p_batch_size=500 per call. Previous code called once with default 5000 rows, exceeding PostgREST's ~8 s statement timeout.