### PR TITLE
fix(plays-and-hits): apply min_amount filter to grouped bets print

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to the Web workspace are documented in this file.
 
 ### Fixed - 2026-04-23
 
+#### Jugadas Agrupadas — impresión ignoraba filtro min_amount
+
+- **`web/src/hooks/fetchs/plays/useBets.ts`**: Agregado `min_amount` a `FetchBetsProps`, `betsKey` y `fetchBets` para que el hook lo envíe como query param al backend.
+- **`web/src/features/plays-and-hits/print-grouped-bets-button.tsx`**: Lee `min_amount` de los URL params y lo pasa a `useBets`, alineando los datos del PDF con los de la tabla.
+
 #### Exportar Diario — diálogo de impresión se cerraba al cambiar configuración
 
 - **`web/src/functions/pdf-shared.ts`**: `openPDFPrintDialog` usaba `setTimeout` de 1000ms para limpiar el iframe, lo que eliminaba el iframe (y cerraba el diálogo) mientras el usuario todavía interactuaba con la configuración de impresión. Reemplazado por el evento `afterprint` que dispara solo cuando el usuario cierra el diálogo.

--- a/web/src/features/plays-and-hits/print-grouped-bets-button.tsx
+++ b/web/src/features/plays-and-hits/print-grouped-bets-button.tsx
@@ -23,6 +23,8 @@ const PrintGroupedBetsButton = () => {
   const quatern = searchParams.get('quatern');
   const isGrouped = searchParams.get('grouped') === 'true';
   const group_id = searchParams.get('group_id');
+  const min_amount_param = searchParams.get('min_amount');
+  const min_amount = min_amount_param ? Math.max(0, parseFloat(min_amount_param) || 0) : undefined;
 
   const { data: bets } = useBets({
     date: isGrouped ? date : null,
@@ -35,6 +37,7 @@ const PrintGroupedBetsButton = () => {
     quatern,
     limit: 9999,
     group_id,
+    min_amount,
   });
 
   const { data: lotteries } = useLotteries();

--- a/web/src/hooks/fetchs/plays/useBets.ts
+++ b/web/src/hooks/fetchs/plays/useBets.ts
@@ -15,6 +15,7 @@ export interface FetchBetsProps {
   ticket_number?: string | null;
   limit?: number;
   group_id?: string | null;
+  min_amount?: number | null;
 }
 
 // ⬇️ Incluir TODOS los filtros en el key (con fallback a '')
@@ -32,6 +33,7 @@ export const betsKey = (p: FetchBetsProps) =>
     p.ticket_number ?? '',
     p.limit ?? '',
     p.group_id ?? '',
+    p.min_amount ?? '',
   ] as const;
 
 // ⬇️ Exportá el fetch para usarlo fuera del hook
@@ -47,6 +49,7 @@ export async function fetchBets({
   ticket_number,
   limit,
   group_id,
+  min_amount,
 }: FetchBetsProps): Promise<IBetEntityFront[]> {
   if (!date) return [];
 
@@ -61,6 +64,7 @@ export async function fetchBets({
   if (ticket_number) params.append('ticket_number', ticket_number);
   if (limit) params.append('limit', limit.toString());
   if (group_id) params.append('group_id', group_id);
+  if (min_amount != null && min_amount > 0) params.append('min_amount', min_amount.toString());
 
   const url = `${BACKEND_ROUTES.bet.base}?${params.toString()}`;
   const res = await fetchWithAuth(url, {


### PR DESCRIPTION
Print button was fetching all grouped bets ignoring the min_amount URL param, causing the PDF to include bets filtered out in the table. Added min_amount support to useBets hook and passed it from PrintGroupedBetsButton.