### PR TITLE
fix(web): improve mobile layout for make-plays

### DIFF
--- a/web/src/components/button/IconButton.tsx
+++ b/web/src/components/button/IconButton.tsx
@@ -27,7 +27,7 @@ export const IconButton = ({
       variant={variant}
       disabled={disabled}
       onClick={onClick}
-      className={cn('w-full sm:w-auto h-10 sm:h-auto flex items-center gap-1 lg:gap-2 justify-center px-2 py-1 lg:px-4 lg:py-2 cursor-pointer  2xl:px-6 2xl:py-4', className)}
+      className={cn('w-full sm:w-auto h-7 sm:h-10 lg:h-auto flex items-center gap-1 lg:gap-2 justify-center px-2 py-0.5 lg:px-4 lg:py-2 cursor-pointer 2xl:px-6 2xl:py-4', className)}
     >
       {icon && <span className="hidden md:inline flex-shrink-0">{icon}</span>}
       <span className="truncate text-xs md:text-sm lg:text-base 2xl:text-lg text-nowrap">{label}</span>

--- a/web/src/components/header-section/index.tsx
+++ b/web/src/components/header-section/index.tsx
@@ -24,7 +24,7 @@ const HeaderSection = ({ title, children, className }: HeaderSectionProps) => {
             size={isLarge ? '24px' : '16px'}
           />
         </span>
-        <p className={'1440:text-2xl text-sm sm:text-base font-medium text-nowrap'}>{title}</p>
+        <p className={'1440:text-2xl hidden sm:block text-sm sm:text-base font-medium text-nowrap'}>{title}</p>
       </Flex>
       {children}
     </Flex>

--- a/web/src/components/layout/index.tsx
+++ b/web/src/components/layout/index.tsx
@@ -5,7 +5,6 @@ import { Outlet, useNavigation } from 'react-router-dom';
 import Footer from '../footer';
 import Header from '../header';
 import Aside from '@/components/aside';
-import MobileBottomNav from '@/components/mobile-bottom-nav';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { Flex, FlexCol } from '../flex';
 import { cn } from '@/lib/utils';
@@ -49,7 +48,6 @@ const Layout = () => {
             </div>
           </main>
           <Footer />
-          <MobileBottomNav />
         </FlexCol>
       </Flex>
     </SidebarProvider>

--- a/web/src/features/make-plays/fill-out-a-ticket.tsx
+++ b/web/src/features/make-plays/fill-out-a-ticket.tsx
@@ -221,7 +221,7 @@ const FillOutATicket = () => {
   return (
     <FlexCol className={'h-fit w-full max-w-full'}>
       <Flex className={'flex-col sm:flex-row gap-1 sm:gap-2 lg:gap-3 sm:items-stretch w-full'}>
-        <Flex className={'flex-1 sm:max-w-[280px] md:max-w-[260px] lg:max-w-[320px] w-full'}>
+        <Flex className={'flex-1 sm:max-w-[280px] md:max-w-[260px] lg:max-w-[320px] w-full order-2 sm:order-1'}>
           <form className={'w-full'}>
             <FlexCol className={'space-y-1 sm:space-y-3 lg:space-y-1 h-full border p-2 sm:p-3 lg:p-1.5 bg-card rounded-[--rounded-form] justify-between'}>
               <Box className={'grid grid-cols-2 items-center gap-1 sm:gap-2 lg:gap-0.5'}>
@@ -319,7 +319,7 @@ const FillOutATicket = () => {
             </FlexCol>
           </form>
         </Flex>
-        <GameTurns />
+        <div className="order-1 sm:order-2 w-full sm:w-auto sm:flex-1"><GameTurns /></div>
       </Flex>
     </FlexCol>
   );


### PR DESCRIPTION
- Hide header-section title on mobile (sm:block)
- Remove MobileBottomNav (replaced by header nav)
- Reorder make-plays: selectors above form on mobile via CSS order
- Reduce IconButton height on mobile (h-7 -> h-10 sm -> auto lg)