### PR TITLE
fix(web): remove unused preload for logo-example.png

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -6,9 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Critical inline styles to prevent white flash before CSS loads -->
     <style>html,body,#root{background-color:#151933;margin:0;padding:0;height:100%}</style>
-    <!-- Preload LCP image (logo) for faster initial render -->
-    <link rel="preload" as="image" href="/logo-example.png" fetchpriority="high" />
-    <title>QuiniApp</title>
+<title>QuiniApp</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Logo is inside the sidebar (hidden on mobile at load time), so the preload triggers a browser warning. fetchpriority="high" on the img tag is sufficient.