### PR TITLE
feat(results): allow 3 or 4 digit results with uniform length validation

### DIFF
--- a/helper/CHANGELOG.md
+++ b/helper/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Helper workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-04-29
+
+#### Results Schema — soporte de 3 o 4 cifras
+
+- **`helper/schemas/results.schema.ts`**: `newResultsSchema` y `editResultsSchema` actualizados. Regex cambiado de `/^\d{4}$/` a `/^\d{3,4}$/`. Agregado `.superRefine()` para validar que todos los resultados tengan la misma longitud (todos 3 o todos 4). El RPC `generate_winners` es compatible sin cambios (usa `ends_with` basado en sufijos).
+
 ### Added - 2026-04-14
 
 #### Ticket Types

--- a/helper/schemas/results.schema.ts
+++ b/helper/schemas/results.schema.ts
@@ -2,8 +2,17 @@ import { z } from 'zod';
 import { dateRegex } from '../functions/dateRegex';
 export const newResultsSchema = z.object({
   results: z
-    .array(z.string().regex(/^\d{4}$/, { message: 'Debe tener exactamente 4 dígitos' }))
-    .length(20, { message: 'Debe haber exactamente 20 números de 4 cifras' }),
+    .array(z.string().regex(/^\d{3,4}$/, { message: 'Debe tener 3 o 4 dígitos' }))
+    .length(20, { message: 'Debe haber exactamente 20 números' })
+    .superRefine((arr, ctx) => {
+      const lengths = new Set(arr.map((r) => r.length));
+      if (lengths.size > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Todos los resultados deben tener la misma cantidad de cifras (3 o 4)',
+        });
+      }
+    }),
   lottery_id: z.string(),
   schedule_id: z.string(),
   date: z
@@ -17,8 +26,17 @@ export const newResultsSchema = z.object({
 
 export const editResultsSchema = z.object({
   results: z
-    .array(z.string().regex(/^\d{4}$/, { message: 'Debe tener exactamente 4 dígitos' }))
-    .length(20, { message: 'Debe haber exactamente 20 números de 4 cifras' })
+    .array(z.string().regex(/^\d{3,4}$/, { message: 'Debe tener 3 o 4 dígitos' }))
+    .length(20, { message: 'Debe haber exactamente 20 números' })
+    .superRefine((arr, ctx) => {
+      const lengths = new Set(arr.map((r) => r.length));
+      if (lengths.size > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Todos los resultados deben tener la misma cantidad de cifras (3 o 4)',
+        });
+      }
+    })
     .optional(),
   lottery_id: z.string().optional(),
   schedule_id: z.string().optional(),

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-04-29
+
+#### Resultados — soporte de 3 o 4 cifras (longitud uniforme)
+
+- **`web/src/features/results/provider/ResultsProvider.tsx`**: `canSave` y validación en `handleSave` actualizados para aceptar 20 resultados de 3 dígitos o 20 de 4 dígitos. Longitudes mixtas siguen siendo inválidas.
+
 ### Added - 2026-04-23
 
 #### Jugadas y Aciertos — filtro cota mínima en modo agrupado

--- a/web/src/features/results/provider/ResultsProvider.tsx
+++ b/web/src/features/results/provider/ResultsProvider.tsx
@@ -67,10 +67,10 @@ export const ResultsProvider: React.FC<React.PropsWithChildren> = ({ children })
   const handleSave = useCallback(() => {
     if (!selectedSchedule || !selectedLottery) return;
 
-    // Validate that all results have exactly 4 digits
-    const allValid = results.every((result) => result.length === 4);
-    if (!allValid) {
-      toast.error('Todos los resultados deben tener exactamente 4 cifras');
+    const allLength3 = results.every((result) => result.length === 3);
+    const allLength4 = results.every((result) => result.length === 4);
+    if (!allLength3 && !allLength4) {
+      toast.error('Todos los resultados deben tener la misma cantidad de cifras (3 o 4)');
       return;
     }
 
@@ -135,10 +135,12 @@ export const ResultsProvider: React.FC<React.PropsWithChildren> = ({ children })
   }, [getResults?.results_id, selectedDate, selectedLottery, selectedSchedule, deleteResults]);
 
   // ---- Derived state
-  const canSave = useMemo(
-    () => onEdit && results.every((result) => result.length === 4),
-    [onEdit, results]
-  );
+  const canSave = useMemo(() => {
+    if (!onEdit) return false;
+    const allLength3 = results.every((r) => r.length === 3);
+    const allLength4 = results.every((r) => r.length === 4);
+    return allLength3 || allLength4;
+  }, [onEdit, results]);
 
   // ---- Effects
   useEffect(() => {


### PR DESCRIPTION
Schema and provider updated to accept all-3 or all-4 digit results. Mixed lengths remain invalid. RPC generate_winners is safe with 3-digit results as ends_with comparison is suffix-based and digit-length-agnostic.