### PR TITLE
feat(current-account): cascade recalculation to subsequent days on up…

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-04-30
+
+#### Cuenta Corriente — recálculo en cascada de días posteriores
+
+- **`api/supabase/migrations/20260430120000_rpc_cascade_current_account_from_date.sql`**: Nueva función `cascade_current_account_from_date(p_from_date_text TEXT, p_organization_id UUID, p_user_id UUID DEFAULT NULL)`. Cuando se actualiza un día pasado, propaga el nuevo `total` y `drag` hacia todos los días siguientes del usuario (o todos los usuarios de la org si `p_user_id` es NULL), actualizando `previous_balance`, `previous_drag`, `total`, `drag` y `leave` (si estaba calculado) en cascada.
+- **`api/src/current-account/repository/current-account.repository.ts`**: Nuevo método `cascadeCurrentAccountFromDateHandler(organization_id, date?, user_id?)` que llama al RPC `cascade_current_account_from_date`.
+- **`api/src/current-account/controller/current-account.controller.ts`**: `calculateCurrentAccountHandler` llama a cascade después de calcular (scope: todos los usuarios de la org). `updateCurrentAccountHandler` llama a cascade para el usuario específico cuyo registro fue editado. `calculateCurrentAccountNetworkHandler` llama a cascade para cada org en la red.
+- **Why**: Al cargar reclamos, pagos o cobros de un día pasado (ej: viernes) en fecha posterior (ej: sábado), el `saldo anterior` del sábado quedaba desactualizado. Ahora cualquier modificación propaga automáticamente el nuevo saldo hacia los días siguientes.
+
 ### Fixed - 2026-04-23
 
 #### Archive RPC — statement timeout + single-batch loop

--- a/api/src/current-account/controller/current-account.controller.ts
+++ b/api/src/current-account/controller/current-account.controller.ts
@@ -54,6 +54,8 @@ export class CurrentAccountController {
         liquidated
       );
 
+      await this.repository.cascadeCurrentAccountFromDateHandler(organization_id, date);
+
       return results.map((res: ICurrentAccountEntityBack) => parseCurrentAccount(res));
     } catch (error) {
       console.error('Creation error:', error);
@@ -112,6 +114,12 @@ export class CurrentAccountController {
         organization_id,
         payload,
         leave
+      );
+
+      await this.repository.cascadeCurrentAccountFromDateHandler(
+        organization_id,
+        currentAccount.date,
+        currentAccount.user_id
       );
 
       return parseCurrentAccount(currentAccount);
@@ -187,6 +195,11 @@ export class CurrentAccountController {
         date,
         leave,
         liquidated
+      );
+
+      const orgIds = await this.repository.getOrganizationNetworkIds(organization_id);
+      await Promise.all(
+        orgIds.map((orgId) => this.repository.cascadeCurrentAccountFromDateHandler(orgId, date))
       );
 
       return results.map((res: ICurrentAccountEntityBack) => parseCurrentAccount(res));

--- a/api/src/current-account/repository/current-account.repository.ts
+++ b/api/src/current-account/repository/current-account.repository.ts
@@ -96,6 +96,26 @@ export class CurrentAccountRepository {
     return Object.values(byUser);
   }
 
+  async cascadeCurrentAccountFromDateHandler(
+    organization_id: string,
+    date?: string,
+    user_id?: string
+  ): Promise<void> {
+    let dateToProcess: string;
+    if (!date) {
+      dateToProcess = dayjs().tz('America/Argentina/Buenos_Aires').format('DD-MM-YYYY');
+    } else {
+      dateToProcess = dayjs(date).format('DD-MM-YYYY');
+    }
+
+    const { error } = await supabase.rpc('cascade_current_account_from_date', {
+      p_from_date_text: dateToProcess,
+      p_organization_id: organization_id,
+      p_user_id: user_id ?? null,
+    });
+    if (error) throw error;
+  }
+
   async updateCurrentAccountHandler(
     current_account_id: string,
     organization_id: string,

--- a/api/supabase/migrations/20260430120000_rpc_cascade_current_account_from_date.sql
+++ b/api/supabase/migrations/20260430120000_rpc_cascade_current_account_from_date.sql
@@ -1,0 +1,103 @@
+CREATE OR REPLACE FUNCTION cascade_current_account_from_date(
+  p_from_date_text TEXT,
+  p_organization_id UUID,
+  p_user_id UUID DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_from_date    DATE := to_date(p_from_date_text, 'DD-MM-YYYY');
+  v_user         RECORD;
+  v_record       RECORD;
+  v_prev_total   NUMERIC;
+  v_prev_drag    NUMERIC; -- effective prev_drag (after leave-reset)
+  v_anchor_drag  NUMERIC;
+  v_anchor_leave NUMERIC;
+  v_new_total    NUMERIC;
+  v_new_drag     NUMERIC;
+  v_new_leave    NUMERIC;
+BEGIN
+  FOR v_user IN
+    SELECT DISTINCT
+      ca.user_id,
+      COALESCE(u.fee_plus, 0) / 100.0 AS fee_plus_pct
+    FROM current_accounts ca
+    JOIN users u ON u.user_id = ca.user_id
+    WHERE ca.date > v_from_date
+      AND ca.organization_id = p_organization_id
+      AND (p_user_id IS NULL OR ca.user_id = p_user_id)
+  LOOP
+    SELECT
+      COALESCE(ca.total, 0),
+      COALESCE(ca.drag, 0),
+      COALESCE(ca.leave, 0)
+    INTO v_prev_total, v_anchor_drag, v_anchor_leave
+    FROM current_accounts ca
+    WHERE ca.user_id = v_user.user_id
+      AND ca.date = v_from_date
+      AND ca.organization_id = p_organization_id;
+
+    IF NOT FOUND THEN
+      CONTINUE;
+    END IF;
+
+    -- Apply leave-reset: if anchor day had leave > 0, next day starts with drag = 0
+    IF v_anchor_leave > 0 AND v_anchor_drag > 0 THEN
+      v_prev_drag := 0;
+    ELSE
+      v_prev_drag := v_anchor_drag;
+    END IF;
+
+    FOR v_record IN
+      SELECT *
+      FROM current_accounts
+      WHERE user_id = v_user.user_id
+        AND date > v_from_date
+        AND organization_id = p_organization_id
+      ORDER BY date ASC
+    LOOP
+      v_new_total := v_prev_total
+                   + COALESCE(v_record.subtotal, 0)
+                   - COALESCE(v_record.collections, 0)
+                   + COALESCE(v_record.paid, 0);
+
+      IF v_user.fee_plus_pct > 0 THEN
+        v_new_drag := v_prev_drag + COALESCE(v_record.subtotal, 0);
+      ELSE
+        v_new_drag := 0;
+      END IF;
+
+      -- Recalculate leave only if it was previously applied on this record
+      IF COALESCE(v_record.leave, 0) > 0 THEN
+        IF v_new_drag > 0 THEN
+          v_new_leave := ROUND(v_new_drag * v_user.fee_plus_pct, 2);
+        ELSE
+          v_new_leave := 0;
+        END IF;
+        v_new_total := v_new_total - v_new_leave;
+      ELSE
+        v_new_leave := 0;
+      END IF;
+
+      UPDATE current_accounts
+      SET
+        previous_balance = v_prev_total,
+        previous_drag    = v_prev_drag,
+        total            = v_new_total,
+        drag             = v_new_drag,
+        leave            = v_new_leave,
+        edited_at        = NOW()
+      WHERE current_account_id = v_record.current_account_id;
+
+      v_prev_total := v_new_total;
+      -- Leave-reset for next record: if this day applied leave, next day's drag starts at 0
+      IF v_new_leave > 0 AND v_new_drag > 0 THEN
+        v_prev_drag := 0;
+      ELSE
+        v_prev_drag := v_new_drag;
+      END IF;
+    END LOOP;
+  END LOOP;
+END;
+$$;

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-04-30
+
+#### Cuenta Corriente — invalidación de caché para todos los días
+
+- **`web/src/hooks/mutations/current-account/useCalculateCurrentAccount.ts`**: `onSuccess` cambiado de `refetchQueries` a `invalidateQueries({ queryKey: ['getCurrentAccount'] })`. El cambio asegura que todos los días cacheados se marquen como stale tras el cálculo/cascade, no solo el día activo en pantalla.
+
 ### Changed - 2026-04-29
 
 #### Resultados — soporte de 3 o 4 cifras (longitud uniforme)

--- a/web/src/hooks/mutations/current-account/useCalculateCurrentAccount.ts
+++ b/web/src/hooks/mutations/current-account/useCalculateCurrentAccount.ts
@@ -25,9 +25,8 @@ export const useCalculateCurrentAccount = () => {
 
   return useMutation({
     mutationFn: (date?: string | null) => calculateCurrentAccount(date),
-    onSuccess: async () => {
-      // Refetch forzado de cuenta corriente para garantizar datos frescos
-      await queryClient.refetchQueries({ queryKey: ['getCurrentAccount'] });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getCurrentAccount'] });
     },
   });
 };


### PR DESCRIPTION
…date

When a past day's record is updated (claims, payments, collections), all subsequent days for the affected user now automatically get their previous_balance, previous_drag, total, drag, and leave recomputed in order, fixing stale saldo anterior after late edits.

- Add RPC cascade_current_account_from_date (migration 20260430120000)
- Add cascadeCurrentAccountFromDateHandler to repository
- Call cascade after calculateCurrentAccountHandler (all users in org)
- Call cascade after updateCurrentAccountHandler (single user only)
- Call cascade after calculateCurrentAccountNetworkHandler (per sub-org)
- Fix useCalculateCurrentAccount: refetchQueries → invalidateQueries so all cached dates are marked stale, not just the active one