### PR TITLE
feat(current-account): allow full manual edit of individual liquidati…

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-05-02
+
+#### Liquidación Individual — campos manuales expandidos
+
+- **`api/src/current-account/controller/current-account.controller.ts`**: `AllowedManualKeys` ahora incluye `pass`, `successes`, `drag`, `revenue`. El payload de `updateCurrentAccountHandler` pasa estos campos al RPC si vienen en el request.
+- **`api/supabase/migrations/20260502120000_update_rpc_manual_override_pass_successes_drag_revenue.sql`**: RPC `update_current_account_recompute` acepta overrides manuales para `pass` (reemplaza cálculo desde tickets), `successes` (reemplaza premios desde tickets), `revenue` (reemplaza subtotal calculado), `drag` (reemplaza cálculo por fee_plus). Si no vienen en `p_props`, el comportamiento anterior se mantiene.
+
 ### Added - 2026-04-30
 
 #### Cuenta Corriente — recálculo en cascada de días posteriores

--- a/api/src/current-account/controller/current-account.controller.ts
+++ b/api/src/current-account/controller/current-account.controller.ts
@@ -34,7 +34,12 @@ type AllowedManualKeys =
   | 'collections'
   | 'bills'
   | 'previous_balance'
-  | 'previous_drag';
+  | 'previous_drag'
+  | 'pass'
+  | 'successes'
+  | 'drag'
+  | 'revenue'
+  | 'leave';
 
 type UpdatePayload = Partial<Pick<IUpdateCurrentAccountEntity, AllowedManualKeys>>;
 export class CurrentAccountController {
@@ -107,6 +112,11 @@ export class CurrentAccountController {
       if (props.previous_drag !== undefined) payload.previous_drag = Number(props.previous_drag);
       if (props.previous_balance !== undefined)
         payload.previous_balance = Number(props.previous_balance);
+      if (props.pass !== undefined) payload.pass = Number(props.pass);
+      if (props.successes !== undefined) payload.successes = Number(props.successes);
+      if (props.drag !== undefined) payload.drag = Number(props.drag);
+      if (props.revenue !== undefined) payload.revenue = Number(props.revenue);
+      if (props.leave !== undefined) payload.leave = Number(props.leave);
       // Llama a tu repo (que a su vez llama al RPC update_current_account_recompute)
 
       const currentAccount = await this.repository.updateCurrentAccountHandler(

--- a/api/supabase/migrations/20260502140000_fix_rpc_leave_priority.sql
+++ b/api/supabase/migrations/20260502140000_fix_rpc_leave_priority.sql
@@ -1,0 +1,217 @@
+-- Fix leave priority: p_calculate_leave always wins over manual has_leave override
+-- Drag and leave are now independent blocks
+
+DROP FUNCTION IF EXISTS update_current_account_recompute(UUID, JSONB, BOOLEAN, UUID);
+
+CREATE OR REPLACE FUNCTION update_current_account_recompute(
+  p_current_account_id UUID,
+  p_props JSONB,
+  p_calculate_leave BOOLEAN,
+  p_organization_id UUID
+)
+RETURNS current_accounts
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cur current_accounts;
+  v_user_id UUID;
+  v_date DATE;
+  row_count INTEGER;
+  v_pass_raw NUMERIC := 0;
+  v_successes_raw NUMERIC := 0;
+  v_fee_pct NUMERIC := 0;
+  v_fee_plus_pct NUMERIC := 0;
+  v_prev_total NUMERIC := 0;
+  v_prev_drag_raw NUMERIC := 0;
+  v_prev_leave NUMERIC := 0;
+  v_prev_bills NUMERIC := 0;
+  v_prev_drag NUMERIC := 0;
+  eff_claims NUMERIC := 0;
+  eff_collections NUMERIC := 0;
+  eff_paid NUMERIC := 0;
+  eff_bills NUMERIC := 0;
+  claims_pos NUMERIC := 0;
+  claims_neg NUMERIC := 0;
+  v_pass NUMERIC := 0;
+  v_successes NUMERIC := 0;
+  v_comm NUMERIC := 0;
+  v_subtotal NUMERIC := 0;
+  v_revenue NUMERIC := 0;
+  v_total NUMERIC := 0;
+  v_drag NUMERIC := 0;
+  v_leave NUMERIC := 0;
+  has_claims BOOLEAN := p_props ? 'claims';
+  has_collections BOOLEAN := p_props ? 'collections';
+  has_paid BOOLEAN := p_props ? 'paid';
+  has_bills BOOLEAN := p_props ? 'bills';
+  has_previous_balance BOOLEAN := p_props ? 'previous_balance';
+  has_previous_drag BOOLEAN := p_props ? 'previous_drag';
+  has_pass BOOLEAN := p_props ? 'pass';
+  has_successes BOOLEAN := p_props ? 'successes';
+  has_drag BOOLEAN := p_props ? 'drag';
+  has_revenue BOOLEAN := p_props ? 'revenue';
+  has_leave BOOLEAN := p_props ? 'leave';
+BEGIN
+  -- 1) Fila actual (lock)
+  SELECT * INTO cur
+  FROM current_accounts
+  WHERE current_account_id = p_current_account_id
+    AND organization_id = p_organization_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'current_account_id % no existe', p_current_account_id;
+  END IF;
+
+  v_user_id := cur.user_id;
+  v_date := cur.date::date;
+
+  -- 2) Tickets del día
+  SELECT
+    COALESCE(SUM(t.total), 0),
+    COALESCE(SUM(t.total_prize), 0)
+  INTO v_pass_raw, v_successes_raw
+  FROM tickets t
+  WHERE t.user_id = v_user_id
+    AND t.date = v_date
+    AND t.deleted_at IS NULL
+    AND t.organization_id = p_organization_id;
+
+  -- 3) Fee y fee_plus del usuario
+  SELECT
+    COALESCE(u.fee, 0) / 100.0,
+    COALESCE(u.fee_plus, 0) / 100.0
+  INTO v_fee_pct, v_fee_plus_pct
+  FROM users u
+  WHERE u.user_id = v_user_id
+    AND u.deleted_at IS NULL
+    AND u.organization_id = p_organization_id;
+
+  -- 4) Estado anterior
+  SELECT
+    COALESCE(ca.total, 0),
+    COALESCE(ca.drag, 0),
+    COALESCE(ca.leave, 0),
+    COALESCE(ca.bills, 0)
+  INTO
+    v_prev_total,
+    v_prev_drag_raw,
+    v_prev_leave,
+    v_prev_bills
+  FROM current_accounts ca
+  WHERE ca.user_id = v_user_id
+    AND ca.date < v_date
+    AND ca.organization_id = p_organization_id
+  ORDER BY ca.date DESC
+  LIMIT 1;
+
+  GET DIAGNOSTICS row_count = ROW_COUNT;
+  IF row_count = 0 THEN
+    v_prev_total := 0;
+    v_prev_drag_raw := 0;
+    v_prev_leave := 0;
+    v_prev_bills := 0;
+  END IF;
+
+  -- 4b) Override previous_balance / previous_drag
+  IF has_previous_balance THEN
+    v_prev_total := (p_props->>'previous_balance')::NUMERIC;
+  END IF;
+
+  IF has_previous_drag THEN
+    v_prev_drag_raw := (p_props->>'previous_drag')::NUMERIC;
+    v_prev_leave := 0;
+  END IF;
+
+  v_prev_drag := CASE
+    WHEN v_prev_leave > 0 AND v_prev_drag_raw > 0 THEN 0
+    ELSE v_prev_drag_raw
+  END;
+
+  -- 5) Manuales efectivos
+  eff_claims := COALESCE((CASE WHEN has_claims THEN (p_props->>'claims')::NUMERIC END), cur.claims, 0);
+  eff_collections := COALESCE((CASE WHEN has_collections THEN (p_props->>'collections')::NUMERIC END), cur.collections, 0);
+  eff_paid := COALESCE((CASE WHEN has_paid THEN (p_props->>'paid')::NUMERIC END), cur.paid, 0);
+  eff_bills := COALESCE((CASE WHEN has_bills THEN (p_props->>'bills')::NUMERIC END), v_prev_bills);
+
+  -- 6) Cálculo base
+  claims_pos := GREATEST(eff_claims, 0);
+  claims_neg := LEAST(eff_claims, 0);
+
+  IF has_pass THEN
+    v_pass := (p_props->>'pass')::NUMERIC;
+  ELSE
+    v_pass := v_pass_raw + claims_pos;
+  END IF;
+
+  v_comm := ROUND(v_pass * v_fee_pct, 2);
+
+  IF has_successes THEN
+    v_successes := (p_props->>'successes')::NUMERIC;
+  ELSE
+    v_successes := v_successes_raw;
+  END IF;
+
+  v_subtotal := v_pass - v_comm - v_successes + claims_neg;
+
+  IF has_revenue THEN
+    v_revenue := (p_props->>'revenue')::NUMERIC;
+  ELSE
+    v_revenue := v_subtotal;
+  END IF;
+
+  v_total := v_prev_total + v_revenue - eff_collections + eff_paid;
+
+  -- 7) DRAG
+  IF has_drag THEN
+    v_drag := (p_props->>'drag')::NUMERIC;
+  ELSIF v_fee_plus_pct > 0 THEN
+    v_drag := v_prev_drag + v_revenue;
+  ELSE
+    v_prev_drag := 0;
+    v_drag := 0;
+  END IF;
+
+  -- 8) LEAVE — p_calculate_leave siempre gana sobre el valor manual
+  IF p_calculate_leave AND v_fee_plus_pct > 0 THEN
+    IF v_drag > 0 THEN
+      v_leave := ROUND(v_drag * v_fee_plus_pct, 2);
+      v_total := v_total - v_leave;
+    ELSE
+      v_leave := 0;
+    END IF;
+  ELSIF has_leave AND NOT p_calculate_leave THEN
+    -- Override manual: solo cuando el checkbox NO está marcado
+    v_leave := (p_props->>'leave')::NUMERIC;
+    v_total := v_total - v_leave;
+  ELSIF v_fee_plus_pct > 0 THEN
+    v_leave := COALESCE(cur.leave, 0);
+  ELSE
+    v_leave := 0;
+  END IF;
+
+  -- 9) Update y retorno
+  UPDATE current_accounts ca
+  SET
+    claims = eff_claims,
+    collections = eff_collections,
+    paid = eff_paid,
+    bills = eff_bills,
+    pass = v_pass,
+    successes = v_successes,
+    cashier_commission = v_comm,
+    subtotal = v_subtotal,
+    revenue = v_revenue,
+    previous_balance = v_prev_total,
+    previous_drag = v_prev_drag,
+    total = v_total,
+    drag = v_drag,
+    leave = v_leave,
+    edited_at = NOW()
+  WHERE ca.current_account_id = p_current_account_id
+    AND ca.organization_id = p_organization_id
+  RETURNING * INTO cur;
+
+  RETURN cur;
+END;
+$$;

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-05-02
+
+#### Liquidación Individual — mejoras de UI y campos editables
+
+- **`web/src/components/modals/UserCurrentAccountModal.tsx`**: Layout del modal ahora apila columnas en mobile (`flex-col sm:flex-row`) para ambas secciones de campos y tablas. Las tablas tienen altura fija con `overflow-y-auto` para scroll independiente en mobile.
+- **`web/src/components/modals/UserCurrentAccountModal.tsx`**: Checkbox "Liquidar deje" tiene `className="border-white bg-white"` para mayor visibilidad.
+- **`web/src/components/modals/UserCurrentAccountModal.tsx`**: Los campos `pass`, `successes`, `drag`, `revenue` ahora se envían al backend en el submit (coincide con cambios en API).
+
 ### Fixed - 2026-04-30
 
 #### Cuenta Corriente — invalidación de caché para todos los días

--- a/web/src/components/modals/UserCurrentAccountModal.tsx
+++ b/web/src/components/modals/UserCurrentAccountModal.tsx
@@ -105,7 +105,7 @@ const UserCurrentAccountModal = ({
     >
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)} className="w-full">
-          <Flex className="justify-center gap-1 sm:gap-3">
+          <Flex className="justify-center gap-1 sm:gap-3 flex-col sm:flex-row">
             <FlexCol className="items-between pt-2">
               <LabelInputForm<ICurrentAccountEntityFront> name="pass" label="Pase" type="number" />
               <LabelInputForm<ICurrentAccountEntityFront>
@@ -162,98 +162,106 @@ const UserCurrentAccountModal = ({
                 label="Arrastre nuevo"
                 type="number"
               />
-              <Flex className="items-center gap-1 sm:gap-3" onClick={() => {}}>
-                <Checkbox checked={calcLeave} onClick={() => handleCalcLeave(calcLeave)} />
+              <Flex className="items-center gap-1 sm:gap-3 px-1 py-1">
+                <Checkbox
+                  checked={calcLeave}
+                  onClick={() => handleCalcLeave(calcLeave)}
+                  className="border-white bg-white"
+                />
                 <Label>Liquidar deje</Label>
               </Flex>
               <LabelInputForm<ICurrentAccountEntityFront> name="leave" label="Deje" type="number" />
             </FlexCol>
           </Flex>
 
-          <Flex className="h-60 gap-1 sm:gap-3 ">
-            <FlexCol>
-              <span className="text-nowrap">Tickets a liquidar</span>
-              <Table className="overflow-hidden">
-                <TableHeader className="border overflow-hidden">
-                  <TableRow>
-                    <TableHead>Número </TableHead>
-                    <TableHead>Monto </TableHead>
-                  </TableRow>
-                </TableHeader>
+          <Flex className="gap-1 sm:gap-3 flex-col sm:flex-row mt-2">
+            <FlexCol className="flex-1 min-w-0">
+              <span className="text-nowrap text-sm mb-1">Tickets a liquidar</span>
+              <div className="h-48 sm:h-60 overflow-y-auto">
+                <Table className="overflow-hidden">
+                  <TableHeader className="border overflow-hidden">
+                    <TableRow>
+                      <TableHead>Número </TableHead>
+                      <TableHead>Monto </TableHead>
+                    </TableRow>
+                  </TableHeader>
 
-                <TableBody className="border">
-                  {isLoadingTickets ? (
-                    <TableRow>
-                      <TableCell colSpan={3}>
-                        <SkeletonList />
-                      </TableCell>
-                    </TableRow>
-                  ) : tickets?.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={14} className="text-center">
-                        <FlexCol className="items-center justify-center gap-1">
-                          <Text size="lg" weight="semibold">No se encontraron tickets</Text>
-                        </FlexCol>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    tickets?.map((ticket: ITicketEntityFront) => (
-                      <TableRow key={ticket.ticket_id}>
-                        <TableCell>{ticket.ticket_number}</TableCell>
-                        <TableCell>{ticket.total}</TableCell>
+                  <TableBody className="border">
+                    {isLoadingTickets ? (
+                      <TableRow>
+                        <TableCell colSpan={3}>
+                          <SkeletonList />
+                        </TableCell>
                       </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+                    ) : tickets?.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={14} className="text-center">
+                          <FlexCol className="items-center justify-center gap-1">
+                            <Text size="lg" weight="semibold">No se encontraron tickets</Text>
+                          </FlexCol>
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      tickets?.map((ticket: ITicketEntityFront) => (
+                        <TableRow key={ticket.ticket_id}>
+                          <TableCell>{ticket.ticket_number}</TableCell>
+                          <TableCell>{ticket.total}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
             </FlexCol>
-            <FlexCol>
-              <span className="text-nowrap">Aciertos a liquidar</span>
-              <Table className="overflow-hidden">
-                <TableHeader className="border overflow-hidden">
-                  <TableRow>
-                    <TableHead>Jugada </TableHead>
-                    <TableHead>Monto</TableHead>
-                    <TableHead>Tipo</TableHead>
-                    <TableHead>Quiniela </TableHead>
-                    <TableHead>Turno</TableHead>
-                    <TableHead>Aciertos</TableHead>
-                    <TableHead>Premio</TableHead>
-                  </TableRow>
-                </TableHeader>
+            <FlexCol className="flex-1 min-w-0">
+              <span className="text-nowrap text-sm mb-1">Aciertos a liquidar</span>
+              <div className="h-48 sm:h-60 overflow-y-auto overflow-x-auto">
+                <Table className="overflow-hidden">
+                  <TableHeader className="border overflow-hidden">
+                    <TableRow>
+                      <TableHead>Jugada </TableHead>
+                      <TableHead>Monto</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead>Quiniela </TableHead>
+                      <TableHead>Turno</TableHead>
+                      <TableHead>Aciertos</TableHead>
+                      <TableHead>Premio</TableHead>
+                    </TableRow>
+                  </TableHeader>
 
-                <TableBody className="border">
-                  {isLoadingBets ? (
-                    <TableRow>
-                      <TableCell colSpan={3}>
-                        <SkeletonList />
-                      </TableCell>
-                    </TableRow>
-                  ) : bets?.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={14} className="text-center">
-                        <FlexCol className="items-center justify-center gap-1">
-                          <Text size="lg" weight="semibold">
-                            No se encontraron jugadas ganadoras
-                          </Text>
-                        </FlexCol>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    bets?.map((bet: IBetEntityFront) => (
-                      <TableRow key={bet.ticket_id}>
-                        <TableCell>{bet.number}</TableCell>
-                        <TableCell>{bet.amount}</TableCell>
-                        <TableCell>{betPlaceDictionary[bet.place]}</TableCell>
-                        <TableCell>{bet.lottery.name}</TableCell>
-                        <TableCell>{bet.schedule.name}</TableCell>
-                        <TableCell>{bet.hits}</TableCell>
-                        <TableCell>{bet.prize}</TableCell>
+                  <TableBody className="border">
+                    {isLoadingBets ? (
+                      <TableRow>
+                        <TableCell colSpan={3}>
+                          <SkeletonList />
+                        </TableCell>
                       </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+                    ) : bets?.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={14} className="text-center">
+                          <FlexCol className="items-center justify-center gap-1">
+                            <Text size="lg" weight="semibold">
+                              No se encontraron jugadas ganadoras
+                            </Text>
+                          </FlexCol>
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      bets?.map((bet: IBetEntityFront) => (
+                        <TableRow key={bet.ticket_id}>
+                          <TableCell>{bet.number}</TableCell>
+                          <TableCell>{bet.amount}</TableCell>
+                          <TableCell>{betPlaceDictionary[bet.place]}</TableCell>
+                          <TableCell>{bet.lottery.name}</TableCell>
+                          <TableCell>{bet.schedule.name}</TableCell>
+                          <TableCell>{bet.hits}</TableCell>
+                          <TableCell>{bet.prize}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
             </FlexCol>
           </Flex>
           <Flex className="justify-center gap-2 mt-6 flex-col sm:flex-row w-full px-2 sm:px-4">

--- a/web/src/components/molecules/LabelInputForm.tsx
+++ b/web/src/components/molecules/LabelInputForm.tsx
@@ -39,11 +39,20 @@ function LabelInputForm<T extends FieldValues>({
       <div className="relative">
         <Input
           id={id}
-          type={type}
+          type={isNumber ? 'text' : type}
+          inputMode={isNumber ? 'decimal' : undefined}
           readOnly={readOnly}
           disabled={disabled}
           className={`${inputClassName} text-white`}
-          {...register(name, { valueAsNumber: isNumber })}
+          {...register(name, {
+            setValueAs: isNumber
+              ? (v) => {
+                  if (v === '' || v === null || v === undefined) return 0;
+                  const parsed = parseFloat(String(v).replace(',', '.'));
+                  return isNaN(parsed) ? 0 : parsed;
+                }
+              : undefined,
+          })}
         />
         {suffix && (
           <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">


### PR DESCRIPTION
…on fields

- Modal: mobile-responsive layout (flex-col sm:flex-row), checkbox border-white bg-white
- LabelInputForm: accept comma as decimal separator (type=text + inputMode=decimal + setValueAs)
- Controller: expand AllowedManualKeys to include pass, successes, drag, revenue, leave
- RPC update_current_account_recompute: manual overrides for pass, successes, revenue, drag, leave; p_calculate_leave always takes priority over manual leave value