### PR TITLE
fix(ticket): support archived tickets in repeat modal and pay flow

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to the API workspace are documented in this file.
 
 - **`api/src/current-account/controller/current-account.controller.ts`**: `AllowedManualKeys` ahora incluye `pass`, `successes`, `drag`, `revenue`. El payload de `updateCurrentAccountHandler` pasa estos campos al RPC si vienen en el request.
 - **`api/supabase/migrations/20260502120000_update_rpc_manual_override_pass_successes_drag_revenue.sql`**: RPC `update_current_account_recompute` acepta overrides manuales para `pass` (reemplaza cálculo desde tickets), `successes` (reemplaza premios desde tickets), `revenue` (reemplaza subtotal calculado), `drag` (reemplaza cálculo por fee_plus). Si no vienen en `p_props`, el comportamiento anterior se mantiene.
+### Fixed - 2026-05-06
+
+#### Archive tickets — `bet_order` faltante en RPC y pago desde archivo
+
+- **`api/supabase/migrations/20260506120000_fix_archive_rpc_bet_order.sql`**: Actualiza `ticket_full_json_plpgsql_archive` para incluir `bet_order` en cada bet del JSON (igual que la versión regular desde `20260102194200`). También alinea el `DISTINCT ON` a `(ticket_id, bet_order, schedule_id, lottery_id)`. Sin el `bet_order`, el modal de repetir ticket asignaba la clave `"undefined"` a todas las apuestas y solo guardaba la primera.
+- **`api/supabase/migrations/20260506120001_add_pay_ticket_archive.sql`**: Nueva función `pay_ticket_archive(p_ticket_number TEXT, p_user_id UUID, p_organization_id UUID)`. Misma lógica que `pay_ticket` pero opera sobre `tickets_archive` y `bets_archive`. Permite pagar tickets ganadores archivados (> 2 días).
+- **`api/src/ticket/repository/ticket.repository.ts`** — `payTicket()`: Si `pay_ticket` RPC lanza `TICKET_NOT_FOUND`, reintenta con `pay_ticket_archive` antes de propagar el error. Así el fallback es transparente para el caller.
+- **`api/src/ticket/controller/ticket.controller.ts`** — `paid()`: Eliminado el try/catch roto que bloqueaba el pago de tickets archivados con error `TICKET_ARCHIVED`. El repository ahora maneja el fallback internamente.
 
 ### Added - 2026-04-30
 

--- a/api/src/ticket/controller/ticket.controller.ts
+++ b/api/src/ticket/controller/ticket.controller.ts
@@ -165,25 +165,7 @@ export class TicketController {
   };
 
   paid = async ({ ticket_number, user_id, organization_id }: IPayTicketEntity) => {
-    try {
-      // payTicket only works on main table (archive is read-only)
-      const result = await this.repository.payTicket({ ticket_number, user_id, organization_id });
-      return result;
-    } catch (error) {
-      // If ticket not found in main table, check if it's in archive
-      if (error instanceof Error && error.message === 'TICKET_NOT_FOUND') {
-        // Repository getByNumber searches both main and archive
-        const archivedTicket = await this.repository.getByNumber(ticket_number, organization_id);
-
-        if (archivedTicket) {
-          // Ticket exists but is archived (too old to pay)
-          throw new Error(
-            'TICKET_ARCHIVED: Este ticket está archivado y ya no puede ser pagado. Por favor contacte al administrador.'
-          );
-        }
-      }
-      // Re-throw original error if not archive-related
-      throw error;
-    }
+    const result = await this.repository.payTicket({ ticket_number, user_id, organization_id });
+    return result;
   };
 }

--- a/api/src/ticket/repository/ticket.repository.ts
+++ b/api/src/ticket/repository/ticket.repository.ts
@@ -284,6 +284,18 @@ export class TicketRepository {
     });
 
     if (error) {
+      if (error.message === 'TICKET_NOT_FOUND') {
+        const { data: archiveData, error: archiveError } = await supabase.rpc(
+          'pay_ticket_archive',
+          {
+            p_ticket_number: ticket_number,
+            p_user_id: user_id,
+            p_organization_id: organization_id,
+          }
+        );
+        if (archiveError) throw archiveError;
+        return archiveData;
+      }
       throw error;
     }
 

--- a/api/supabase/migrations/20260506120000_fix_archive_rpc_bet_order.sql
+++ b/api/supabase/migrations/20260506120000_fix_archive_rpc_bet_order.sql
@@ -1,0 +1,132 @@
+-- ============================================================================
+-- Migration: Fix ticket_full_json_plpgsql_archive to include bet_order
+-- ============================================================================
+-- Mirrors the fix applied to the regular RPC in 20260102194200.
+-- The archive version was created without bet_order in the JSON output,
+-- causing the repeat-ticket modal to key all bets as "undefined" and drop
+-- all but the first bet for archived tickets.
+-- Also aligns DISTINCT ON clause with the regular RPC.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.ticket_full_json_plpgsql_archive(UUID, UUID);
+
+CREATE OR REPLACE FUNCTION public.ticket_full_json_plpgsql_archive(
+  p_ticket_id UUID,
+  p_organization_id UUID
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_result jsonb;
+BEGIN
+  WITH t AS (
+    SELECT *
+    FROM public.tickets_archive
+    WHERE ticket_id = p_ticket_id
+      AND organization_id = p_organization_id
+  ),
+  br AS (
+    SELECT
+      b.ticket_id,
+      b.number,
+      b.amount,
+      b.place,
+      b."with",
+      b.position,
+      b.bet_order,
+      s.schedule_id,
+      s."time" AS schedule_time,
+      jsonb_build_object(
+        'schedule_id', s.schedule_id,
+        'name', s.name,
+        'time', to_char(s."time", 'HH24:MI:SS')
+      ) AS schedule_obj,
+      l.lottery_id,
+      l.created_at AS lottery_created_at,
+      jsonb_build_object(
+        'lottery_id', l.lottery_id,
+        'name', l.name
+      ) AS lottery_obj
+    FROM public.bets_archive b
+    JOIN public.schedules s ON s.schedule_id = b.schedule_id AND s.organization_id = p_organization_id
+    JOIN public.lotteries l ON l.lottery_id = b.lottery_id AND l.organization_id = p_organization_id
+    WHERE b.ticket_id = p_ticket_id
+      AND b.organization_id = p_organization_id
+  ),
+  br_dedup AS (
+    SELECT DISTINCT ON (
+      ticket_id, bet_order, schedule_id, lottery_id
+    )
+      ticket_id, number, amount, place, "with", position,
+      schedule_id, schedule_time, schedule_obj,
+      lottery_id, lottery_created_at, lottery_obj,
+      bet_order
+    FROM br
+    ORDER BY
+      ticket_id, bet_order, schedule_id, lottery_id,
+      lottery_created_at DESC
+  ),
+  bet_sched AS (
+    SELECT
+      bet_order,
+      number, amount, place, "with", position,
+      schedule_id, schedule_obj, schedule_time,
+      jsonb_agg(lottery_obj ORDER BY lottery_created_at DESC) AS lotteries
+    FROM br_dedup
+    GROUP BY bet_order, number, amount, place, "with", position, schedule_id, schedule_obj, schedule_time
+  ),
+  bets_grouped AS (
+    SELECT
+      bet_order,
+      number, amount, place, "with", position,
+      jsonb_agg(
+        jsonb_build_object(
+          'schedule', schedule_obj,
+          'lotteries', lotteries
+        )
+        ORDER BY schedule_time ASC
+      ) AS scheduleLottery
+    FROM bet_sched
+    GROUP BY bet_order, number, amount, place, "with", position
+  ),
+  bets_json AS (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'bet_order', bet_order,
+        'number', number,
+        'amount', amount,
+        'place', place,
+        'with', "with",
+        'position', position,
+        'scheduleLottery', scheduleLottery
+      )
+      ORDER BY bet_order ASC
+    ) AS bets
+    FROM bets_grouped
+  )
+  SELECT
+    jsonb_build_object(
+      'ticket_id', t.ticket_id,
+      'user_id', t.user_id,
+      'user_name', t.user_name,
+      'ticket_number', t.ticket_number,
+      'date', t.date,
+      'paid', t.paid,
+      'winner', t.winner,
+      'total', t.total,
+      'total_prize', t.total_prize,
+      'created_at', t.created_at,
+      'deleted_at', t.deleted_at,
+      'deleted_by', t.deleted_by,
+      'hits', t.hits,
+      'bets', coalesce(bj.bets, '[]'::jsonb)
+    )
+  INTO v_result
+  FROM t
+  CROSS JOIN bets_json bj;
+
+  RETURN v_result;
+END;
+$$;

--- a/api/supabase/migrations/20260506120001_add_pay_ticket_archive.sql
+++ b/api/supabase/migrations/20260506120001_add_pay_ticket_archive.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Migration: Add pay_ticket_archive function
+-- ============================================================================
+-- Allows paying winner tickets that have been moved to tickets_archive /
+-- bets_archive (older than the active-days retention window).
+-- Called as fallback by the repository when pay_ticket raises TICKET_NOT_FOUND.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION pay_ticket_archive(
+  p_ticket_number TEXT,
+  p_user_id UUID,
+  p_organization_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_ticket_id UUID;
+  v_ticket_user_id UUID;
+  v_ticket_paid BOOLEAN;
+  v_bets_updated INTEGER;
+  v_current_timestamp TIMESTAMPTZ;
+BEGIN
+  v_current_timestamp := NOW();
+
+  SELECT ticket_id, user_id, paid
+  INTO v_ticket_id, v_ticket_user_id, v_ticket_paid
+  FROM tickets_archive
+  WHERE ticket_number = p_ticket_number
+    AND organization_id = p_organization_id
+    AND winner = TRUE
+    AND deleted_at IS NULL
+  FOR UPDATE;
+
+  IF v_ticket_id IS NULL THEN
+    RAISE EXCEPTION 'TICKET_NOT_FOUND';
+  END IF;
+
+  IF v_ticket_user_id != p_user_id THEN
+    RAISE EXCEPTION 'TICKET_NOT_OWNED';
+  END IF;
+
+  IF v_ticket_paid = TRUE THEN
+    RAISE EXCEPTION 'TICKET_ALREADY_PAID';
+  END IF;
+
+  UPDATE tickets_archive
+  SET paid = TRUE
+  WHERE ticket_id = v_ticket_id
+    AND organization_id = p_organization_id;
+
+  UPDATE bets_archive
+  SET
+    paid = TRUE,
+    edited_at = v_current_timestamp
+  WHERE ticket_id = v_ticket_id
+    AND organization_id = p_organization_id
+    AND winner = TRUE
+    AND user_id = p_user_id
+    AND deleted_at IS NULL;
+
+  GET DIAGNOSTICS v_bets_updated = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'ticket_id', v_ticket_id,
+    'bets_updated', v_bets_updated
+  );
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE;
+END;
+$$;


### PR DESCRIPTION
- ticket_full_json_plpgsql_archive: add bet_order to JSON output and align DISTINCT ON with regular RPC; fixes repeat-ticket modal keying all bets as undefined and dropping all but the first
- add pay_ticket_archive RPC operating on tickets_archive/bets_archive
- payTicket() falls back to pay_ticket_archive on TICKET_NOT_FOUND
- remove broken try/catch in controller that blocked archive payments