### PR TITLE
fix(auth): harden rate limits against CGNAT-induced disconnections

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Skill(code-review:code-review)",
       "WebFetch(domain:api.github.com)",
       "mcp__supabase__list_projects",
-      "mcp__supabase__get_advisors"
+      "mcp__supabase__get_advisors",
+      "Skill(caveman:caveman-commit)"
     ],
     "deny": [
       "Bash(git push:*)"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-05-16 (Rate Limiting)
+
+#### Rate Limit Tuning — CGNAT tolerance
+- **`api/src/config/rate-limit.config.ts`**: Adjusted hard caps and slow-down thresholds to prevent false positives for users sharing IPs via CGNAT
+  - PRIVATE hard cap: 2000 → 5000 / 5 min (was 15 min)
+  - PUBLIC hard cap: 2000 → 3000 / 5 min (was 15 min)
+  - LOGIN slow-down: 5 req/5s → 20 req/30s (wider window for fast typers)
+  - PUBLIC slow-down: 40 req/10s → 60 req/10s
+  - Why: lottery agencies in same ISP area share the same public IP (CGNAT); previous limits triggered disconnections under concurrent normal usage
+
 ### Fixed - 2026-05-16
 
 #### Current Account

--- a/api/src/config/rate-limit.config.ts
+++ b/api/src/config/rate-limit.config.ts
@@ -7,28 +7,28 @@ const parseIntEnv = (key: string, defaultValue: number): number => {
 // Primary DDoS mitigation is express-slow-down (adds delay); these are last-resort blocks.
 export const RATE_LIMIT_CONFIG = {
   LOGIN: {
-    windowMs: 15 * 60 * 1000, // 15 min
+    windowMs: 15 * 60 * 1000, // 15 min — security-sensitive, keep long window
     max: parseIntEnv('RATE_LIMIT_LOGIN_MAX', 100),
   },
   AUTH: {
-    windowMs: 15 * 60 * 1000,
+    windowMs: 15 * 60 * 1000, // 15 min — security-sensitive, keep long window
     max: parseIntEnv('RATE_LIMIT_AUTH_MAX', 500),
   },
   PUBLIC: {
-    windowMs: 15 * 60 * 1000,
-    max: parseIntEnv('RATE_LIMIT_PUBLIC_MAX', 2000),
+    windowMs: 5 * 60 * 1000, // 5 min — shorter window = faster reset
+    max: parseIntEnv('RATE_LIMIT_PUBLIC_MAX', 3000),
   },
   PRIVATE: {
-    windowMs: 15 * 60 * 1000,
-    max: parseIntEnv('RATE_LIMIT_PRIVATE_MAX', 2000),
+    windowMs: 5 * 60 * 1000, // 5 min — shorter window = faster reset
+    max: parseIntEnv('RATE_LIMIT_PRIVATE_MAX', 5000),
   },
 };
 
 export const SLOW_DOWN_CONFIG = {
-  // Login: tight window — 5 req / 5 s → 5 s delay (bot detection)
+  // Login: 20 req / 30 s → 5 s delay (allows fast typers, catches bots)
   LOGIN: {
-    windowMs: parseIntEnv('SLOW_DOWN_LOGIN_WINDOW_MS', 5 * 1000),
-    delayAfter: parseIntEnv('SLOW_DOWN_LOGIN_DELAY_AFTER', 5),
+    windowMs: parseIntEnv('SLOW_DOWN_LOGIN_WINDOW_MS', 30 * 1000),
+    delayAfter: parseIntEnv('SLOW_DOWN_LOGIN_DELAY_AFTER', 20),
     delayMs: parseIntEnv('SLOW_DOWN_LOGIN_DELAY_MS', 5000),
   },
   // Auth (refresh, validate, logout): 15 req / 10 s → 3 s delay
@@ -37,10 +37,10 @@ export const SLOW_DOWN_CONFIG = {
     delayAfter: parseIntEnv('SLOW_DOWN_AUTH_DELAY_AFTER', 15),
     delayMs: parseIntEnv('SLOW_DOWN_AUTH_DELAY_MS', 3000),
   },
-  // Public API: 40 req / 10 s → 2 s delay (scraper / flood protection)
+  // Public API: 60 req / 10 s → 2 s delay (scraper / flood protection)
   PUBLIC: {
     windowMs: parseIntEnv('SLOW_DOWN_PUBLIC_WINDOW_MS', 10 * 1000),
-    delayAfter: parseIntEnv('SLOW_DOWN_PUBLIC_DELAY_AFTER', 40),
+    delayAfter: parseIntEnv('SLOW_DOWN_PUBLIC_DELAY_AFTER', 60),
     delayMs: parseIntEnv('SLOW_DOWN_PUBLIC_DELAY_MS', 2000),
   },
   // Private API (authenticated): 80 req / 10 s → 2 s delay

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,4 +1,4 @@
-import express, { Response } from 'express';
+import express, { Request, Response } from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
@@ -100,10 +100,16 @@ morgan.token('error-info', (req, res) => {
   return '';
 });
 
-// Formato custom que incluye error-info para producción
+// Custom Morgan token para mostrar el username del usuario autenticado
+morgan.token('username', (req) => {
+  const expressReq = req as unknown as Request;
+  return expressReq.user?.user?.username ?? '-';
+});
+
+// Formato custom que incluye username y error-info
 const morganFormat = IS_LOCAL
-  ? 'dev'
-  : ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :error-info ":referrer" ":user-agent"';
+  ? ':method :url :status :response-time ms - :username'
+  : ':remote-addr - :username [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :error-info ":referrer" ":user-agent"';
 
 app.use(morgan(morganFormat));
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Fixed - 2026-05-16 (Auth)
+
+#### Rate Limit 429 Resilience
+- **`web/src/lib/apiClient.ts`**: `refreshAccessToken()` now returns `true` on HTTP 429 instead of `false`
+  - Previous behavior: 429 from `/api/auth/refresh` triggered immediate logout
+  - New behavior: rate-limited refresh is treated as success; session stays alive; periodic `validate()` (5 min) handles actual expiration
+  - Why: CGNAT means many users share the same IP; if the AUTH hard cap is hit, users should not be disconnected
+
 ### Added - 2026-05-16 (Security)
 
 #### CSRF Header

--- a/web/src/lib/apiClient.ts
+++ b/web/src/lib/apiClient.ts
@@ -55,8 +55,7 @@ class ApiClient {
         },
       });
 
-      // If no refresh token is available (old session), return false
-      // This will trigger logout in the handler
+      if (response.status === 429) return true; // rate limited — session likely valid, let validate() handle expiry
       if (!response.ok) {
         return false;
       }


### PR DESCRIPTION
IP-based hard caps were too low for shared NAT environments where multiple agencies share the same public IP. Raised private/public caps and shortened window for faster recovery. Relaxed login slow-down window to avoid penalizing fast typers.

Also fixes the root semantic bug: HTTP 429 from /auth/refresh no longer triggers logout — rate limiting is not an auth failure. Session stays alive; validate() handles actual expiration.

- PRIVATE hard cap: 2000/15min → 5000/5min
- PUBLIC hard cap: 2000/15min → 3000/5min
- LOGIN slow-down: 5 req/5s → 20 req/30s
- PUBLIC slow-down: 40 req/10s → 60 req/10s
- apiClient: return true on 429 from refresh endpoint