### PR TITLE
fix(api): replace lusca CSRF with stateless X-Requested-With check

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,8 +21,7 @@ import {
   publicSlowDown,
   privateSlowDown,
 } from './middlewares/rate-limit.middleware';
-import expressSession from 'express-session';
-import lusca from 'lusca';
+import { csrfProtection } from './middlewares/csrf.middleware';
 
 import {
   PORT,
@@ -115,19 +114,8 @@ app.use(morgan(morganFormat));
 
 app.use(cookieParser());
 
-// ---- Session (required by lusca CSRF) ----
-app.use(
-  expressSession({
-    secret: process.env.SESSION_SECRET ?? 'session-dev-secret-change-in-prod',
-    resave: false,
-    saveUninitialized: true,
-    name: 'sid',
-    cookie: { httpOnly: true, sameSite: 'lax', secure: IS_PRODUCTION },
-  })
-);
-
-// ---- CSRF (lusca angular mode: sets XSRF-TOKEN cookie, validates X-XSRF-TOKEN header) ----
-app.use(lusca.csrf({ angular: true }));
+// ---- CSRF (stateless: validates X-Requested-With: XMLHttpRequest header) ----
+app.use(csrfProtection);
 
 // ---- Rate Limiters (ANTES de body parsers, más específicos primero) ----
 // slow-down: adds delay on repeated requests (silent DDoS mitigation)


### PR DESCRIPTION
lusca.csrf() uses express-session MemoryStore — breaks on multi-instance deployments (Railway) because session is not shared across instances. Each instance has its own CSRF token; requests routed to a different instance always fail with "CSRF token mismatch" → 500 on refresh/PATCH.

Replaced with csrf.middleware.ts (already in codebase): validates X-Requested-With: XMLHttpRequest header on all non-GET requests. Frontend already sends this header on every state-changing call. Stateless — works correctly in multi-instance environments.