### PR TITLE
feat(ha): add backup backend with transparent failover

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -105,6 +105,24 @@ CORS_EXTRA_ORIGINS=
 DEFAULT_ORG_ID=your_default_organization_id
 
 # =====================================
+# High Availability (Railway main + Render backup)
+# =====================================
+# Identifies this instance in /health responses and logs (e.g. 'railway' | 'render').
+INSTANCE_NAME=main
+
+# Whether this instance runs the singleton background jobs (archive cron + session cleanup).
+# Keep 'true' on the main instance; set 'false' on the passive backup to avoid double execution.
+ENABLE_BACKGROUND_JOBS=true
+
+# Public /health URL of the backup instance. The main instance pings it to keep Render's free
+# tier warm. Only set this on the MAIN instance; leave empty on the backup. Optional.
+BACKUP_HEALTH_URL=
+
+# IMPORTANT: the backup MUST share identical JWT_SECRET_ACCESS, JWT_SECRET_REFRESH,
+# JWT_SECRET_SUPABASE, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY and cookie config with the main
+# instance — otherwise tokens won't validate across instances and sessions break on failover.
+
+# =====================================
 # Emergency Owner Access (Scripts Only)
 # =====================================
 # IMPORTANT: These variables are ONLY used by emergency scripts

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the API workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-06-27 (High Availability)
+
+#### Backup backend / transparent failover (Railway main + Render backup)
+- **Health endpoints** — `api/src/health/health.route.ts` (mounted in `api/src/index.ts` before
+  auth/csrf/rate-limit/logging):
+  - `GET /health` — shallow liveness `{ status, instance, uptime }`. Used by the keep-warm pinger
+    and uptime monitors. Reachable directly on the backend host, not only via the Vercel proxy.
+  - `GET /health/deep` — verifies Supabase connectivity (cheap `SELECT`), returns 200/503.
+- **Job gating** — `api/src/index.ts`: singleton jobs (archive cron + session cleanup) now run only
+  when `ENABLE_BACKGROUND_JOBS=true`, so the passive backup doesn't double-execute them. Per-instance
+  flush jobs (session monitor + device stats) keep running on every instance so each persists the
+  buffer of requests it served (matters when the backup serves traffic during a failover).
+- **Keep-warm job** — `api/src/utils/keep-warm.job.ts`: the main instance pings the backup's `/health`
+  every 10 min (gated by `ENABLE_BACKGROUND_JOBS`, no-op when `BACKUP_HEALTH_URL` unset) to keep
+  Render's free tier from sleeping.
+- **New envs** — `api/envs.ts` + `.env.example`: `INSTANCE_NAME` (default `main`),
+  `ENABLE_BACKGROUND_JOBS` (default `true`), `BACKUP_HEALTH_URL` (optional).
+- **Production start script** — `api/package.json`: added `start: tsx src/index.ts` (no compiled
+  dist/ exists and the project uses tsconfig path aliases, so tsx is the runtime, same as dev).
+- **Deploy** — `render.yaml` (repo root): free-tier web service for the backup with
+  `ENABLE_BACKGROUND_JOBS=false`. **Requires identical JWT secrets, Supabase config and cookie
+  settings as Railway** so sessions survive the switch.
+
 ### Changed - 2026-05-16 (Rate Limiting)
 
 #### Rate Limit Tuning — CGNAT tolerance

--- a/api/envs.ts
+++ b/api/envs.ts
@@ -77,3 +77,20 @@ function must<T extends string | undefined>(val: T, name: string): string {
 export const DEFAULT_ORG_ID = must(process.env.DEFAULT_ORG_ID, 'DEFAULT_ORG_ID');
 
 export const ARCHIVE_DAYS_TO_KEEP = parseInt(process.env.ARCHIVE_DAYS_TO_KEEP || '2');
+
+// =====================================
+// High Availability (Railway main + Render backup)
+// =====================================
+
+// Human-readable identifier for this instance (e.g. 'railway' | 'render'). Surfaced by /health.
+export const INSTANCE_NAME = process.env.INSTANCE_NAME ?? 'main';
+
+// Whether this instance runs the singleton background jobs (archive cron, session cleanup).
+// Default true so the existing single-instance deploy is unaffected. Set to false on the
+// passive backup (Render) so those jobs only run on the main (Railway) instance.
+export const ENABLE_BACKGROUND_JOBS =
+  (process.env.ENABLE_BACKGROUND_JOBS ?? 'true').toLowerCase() === 'true';
+
+// Public /health URL of the backup instance. The main instance pings it periodically to keep
+// the Render free tier warm. Optional — keep-warm is skipped when unset.
+export const BACKUP_HEALTH_URL = process.env.BACKUP_HEALTH_URL ?? '';

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.json",
         "dev": "tsx watch src/index.ts",
+        "start": "tsx src/index.ts",
         "lint": "eslint 'src/**/*.{ts,tsx}'",
         "format": "prettier --write 'src/**/*.{ts,tsx,json,md}'",
         "test": "dotenv -e .env.test -- cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --detectOpenHandles",

--- a/api/src/health/health.route.ts
+++ b/api/src/health/health.route.ts
@@ -1,0 +1,49 @@
+import { Router, Request, Response } from 'express';
+import { supabase } from '@database/db.connection';
+import { INSTANCE_NAME } from 'api/envs';
+
+/**
+ * Health endpoints for the high-availability setup (Railway main + Render backup).
+ *
+ * Mounted BEFORE auth, rate-limit and CSRF so it is public, cheap and unthrottled.
+ * Must be reachable directly on the backend host (e.g. https://<render-host>/health),
+ * not only through the Vercel proxy, so the keep-warm pinger and uptime monitors can hit it.
+ */
+export const healthRouter = Router();
+
+/**
+ * Shallow liveness check. Used by the keep-warm pinger and uptime monitors.
+ * Returns 200 as long as the process is up — does NOT touch the database.
+ */
+healthRouter.get('/health', (_req: Request, res: Response) => {
+  res.status(200).json({
+    status: 'ok',
+    instance: INSTANCE_NAME,
+    uptime: process.uptime(),
+  });
+});
+
+/**
+ * Deep readiness check. Verifies Supabase connectivity with a cheap query.
+ * Returns 503 when the database is unreachable. For monitoring/alerting only —
+ * the proxy failover does NOT poll this; it reacts to connection errors per request.
+ */
+healthRouter.get('/health/deep', async (_req: Request, res: Response) => {
+  try {
+    const { error } = await supabase.from('sessions').select('session_id').limit(1);
+    if (error) throw error;
+
+    res.status(200).json({
+      status: 'ok',
+      instance: INSTANCE_NAME,
+      db: 'up',
+      uptime: process.uptime(),
+    });
+  } catch {
+    res.status(503).json({
+      status: 'error',
+      instance: INSTANCE_NAME,
+      db: 'down',
+    });
+  }
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,8 @@ import { startSessionMonitorJob, flushActivityCache } from './session/job/sessio
 import { startDeviceStatsJob, flushDeviceStats } from './analytics/job/device-stats.job';
 import { getCronService } from './cron/service/cron.service';
 import { initializeActiveDaysCache } from './archive/helper/archive-helper';
+import { startKeepWarmJob } from './utils/keep-warm.job';
+import { healthRouter } from './health/health.route';
 import {
   loginRateLimit,
   authRateLimit,
@@ -33,6 +35,8 @@ import {
   FRONT_URL_DEV,
   ALLOW_VERCEL_PREVIEWS,
   CORS_EXTRA_ORIGINS,
+  ENABLE_BACKGROUND_JOBS,
+  INSTANCE_NAME,
 } from 'api/envs';
 import { URL } from 'url';
 import { ARCHIVE_DAYS_TO_KEEP } from 'api/envs';
@@ -84,6 +88,10 @@ app.use((req, res, next) => {
 });
 app.use(corsMiddleware);
 app.options('*', corsMiddleware); // preflight
+
+// ---- Health (público, sin auth/csrf/rate-limit/logging) ----
+// Antes de morgan para no llenar logs con los pings del keep-warm/uptime monitors.
+app.use(healthRouter);
 
 // ---- Middlewares globales ----
 // Custom Morgan token para mostrar info de errores en logs
@@ -158,12 +166,15 @@ app.use(errorHandler);
 // Solo iniciar servidor si no estamos en entorno de test
 if (process.env.NODE_ENV !== 'test') {
   app.listen(PORT, async () => {
-    console.log(`Servidor corriendo en ${BACKEND_URL}:${PORT} [node_env=${NODE_ENV}]`);
+    console.log(
+      `Servidor corriendo en ${BACKEND_URL}:${PORT} [node_env=${NODE_ENV}] [instance=${INSTANCE_NAME}]`
+    );
     console.log('[CORS] allowed origins:', baseAllowedOrigins);
     if (ALLOW_VERCEL_PREVIEWS) console.log('[CORS] Vercel previews habilitadas (*.vercel.app)');
 
-    // Start session cleanup job (runs every hour)
-    startSessionCleanupJob();
+    // ---- Flush jobs por-instancia (corren en CADA instancia) ----
+    // Cada instancia persiste su propio buffer en memoria de los requests que sirvió.
+    // Esto importa cuando el backup (Render) recibe tráfico durante un failover.
 
     // Start session monitor job (flushes activity cache + checks revocations every 30 min)
     startSessionMonitorJob();
@@ -174,10 +185,22 @@ if (process.env.NODE_ENV !== 'test') {
     // Initialize active days cache (for query routing)
     await initializeActiveDaysCache();
 
-    // Start archive cron job (runs daily at 3:00 AM Argentina Time)
-    const cronService = getCronService(ARCHIVE_DAYS_TO_KEEP);
-    cronService.startArchiveCron();
-    console.log('[Archive] Cron job initialized - Daily archiving of old bets/tickets');
+    // ---- Jobs singleton (deben correr en UNA sola instancia: la main) ----
+    // Gated por ENABLE_BACKGROUND_JOBS para evitar doble ejecución con el backup activo.
+    if (ENABLE_BACKGROUND_JOBS) {
+      // Start session cleanup job (runs every hour)
+      startSessionCleanupJob();
+
+      // Start archive cron job (runs daily at 3:00 AM Argentina Time)
+      const cronService = getCronService(ARCHIVE_DAYS_TO_KEEP);
+      cronService.startArchiveCron();
+      console.log('[Archive] Cron job initialized - Daily archiving of old bets/tickets');
+
+      // Keep the backup instance warm by pinging its /health (no-op if BACKUP_HEALTH_URL unset)
+      startKeepWarmJob();
+    } else {
+      console.log('[Jobs] ENABLE_BACKGROUND_JOBS=false — singleton jobs disabled (passive backup)');
+    }
   });
 }
 

--- a/api/src/utils/keep-warm.job.ts
+++ b/api/src/utils/keep-warm.job.ts
@@ -1,0 +1,75 @@
+import { BACKUP_HEALTH_URL } from 'api/envs';
+
+/**
+ * Keep-Warm Job
+ *
+ * The Render free tier sleeps after ~15 min without inbound traffic (cold start ~50s).
+ * To keep the backup instance warm, the main (Railway) instance pings its /health endpoint
+ * periodically. Gated by ENABLE_BACKGROUND_JOBS (only the main instance runs it).
+ *
+ * Failures are swallowed (the backup may legitimately be down) — they must never crash main.
+ */
+
+// Ping every 10 minutes — comfortably under Render's ~15 min idle-to-sleep window.
+const KEEP_WARM_INTERVAL_MS = 10 * 60 * 1000;
+
+// Abort the ping if the backup doesn't answer quickly; a cold backup can take ~50s and we
+// don't want a hung request piling up.
+const PING_TIMEOUT_MS = 30 * 1000;
+
+let keepWarmIntervalId: ReturnType<typeof setInterval> | null = null;
+
+async function pingBackup(): Promise<void> {
+  if (!BACKUP_HEALTH_URL) return;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(BACKUP_HEALTH_URL, { method: 'GET', signal: controller.signal });
+    if (!res.ok) {
+      console.warn(`[KeepWarm] ⚠️  Backup responded ${res.status} at ${BACKUP_HEALTH_URL}`);
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(`[KeepWarm] ⚠️  Could not reach backup (${reason})`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Start pinging the backup instance to keep it warm.
+ * No-op when BACKUP_HEALTH_URL is unset.
+ */
+export function startKeepWarmJob(): void {
+  if (!BACKUP_HEALTH_URL) {
+    console.log('[KeepWarm] BACKUP_HEALTH_URL not set — keep-warm disabled');
+    return;
+  }
+  if (keepWarmIntervalId) {
+    console.warn('[KeepWarm] ⚠️  Job already running, skipping start');
+    return;
+  }
+
+  console.log(
+    `[KeepWarm] 🔥 Pinging backup every ${KEEP_WARM_INTERVAL_MS / 1000 / 60} min: ${BACKUP_HEALTH_URL}`
+  );
+
+  // Ping once on start, then on the interval.
+  void pingBackup();
+  keepWarmIntervalId = setInterval(() => {
+    void pingBackup();
+  }, KEEP_WARM_INTERVAL_MS);
+}
+
+/**
+ * Stop the keep-warm job (graceful shutdown).
+ */
+export function stopKeepWarmJob(): void {
+  if (keepWarmIntervalId) {
+    clearInterval(keepWarmIntervalId);
+    keepWarmIntervalId = null;
+    console.log('[KeepWarm] 🛑 Keep-warm job stopped');
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,8 @@ export default [
         clearTimeout: 'readonly',
         setInterval: 'readonly',
         clearInterval: 'readonly',
+        fetch: 'readonly',
+        AbortController: 'readonly',
       },
     },
     plugins: {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,64 @@
+# Render Blueprint — backup backend for QuiniApp (free tier).
+#
+# Passive standby for the main Railway backend. Shares the SAME Supabase DB and the SAME JWT
+# secrets so sessions minted by Railway validate here (transparent failover via the Vercel proxy).
+#
+# NOTE: `npm install` (not `npm ci --omit=dev`) is used on purpose — the start command runs `tsx`,
+# which is a devDependency. The project has no compiled dist/ output and relies on tsconfig path
+# aliases, so tsx is the runtime (same as local dev).
+services:
+  - type: web
+    name: quiniapp-api-backup
+    runtime: node
+    plan: free
+    region: oregon
+    rootDir: .
+    buildCommand: npm install
+    startCommand: npm --workspace api run start
+    healthCheckPath: /health
+    envVars:
+      # ---- HA / instance config ----
+      - key: INSTANCE_NAME
+        value: render
+      - key: ENABLE_BACKGROUND_JOBS # passive backup: do NOT run singleton jobs (archive/cleanup)
+        value: "false"
+
+      # ---- Environment flags ----
+      - key: ENVIROMENT
+        value: PRODUCTION
+      - key: NODE_ENV
+        value: production
+      - key: SUPABASE_ENVIROMENT
+        value: REMOTE
+      - key: FRONT_URL_ENVIROMENT
+        value: PRODUCTION
+
+      # ---- Cookies (MUST match Railway so tokens are accepted across instances) ----
+      - key: COOKIE_SECURE
+        value: "true"
+      - key: COOKIE_SAME_SITE
+        value: lax
+      - key: COOKIE_DOMAIN
+        value: "" # host-only; cookies live on the Vercel domain via the proxy
+
+      # ---- URL of this Render service (required by envs.ts BACKEND_URL) ----
+      - key: URL
+        sync: false # e.g. https://quiniapp-api-backup.onrender.com
+
+      # ---- Frontend / CORS (same value as Railway) ----
+      - key: FRONT_URL_PRODUCTION
+        sync: false
+
+      # ---- Secrets: set in the Render dashboard, identical to Railway ----
+      - key: JWT_SECRET_ACCESS
+        sync: false
+      - key: JWT_SECRET_REFRESH
+        sync: false
+      - key: JWT_SECRET_SUPABASE
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: DEFAULT_ORG_ID
+        sync: false

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Added - 2026-06-27 (High Availability)
+
+#### Transparent backend failover in the Vercel proxy
+- **`web/api/api-proxy.ts`**: the serverless proxy now fails over from the main backend
+  (`API_BASE_URL`, Railway) to a backup (`API_BASE_URL_BACKUP`, Render) when the main is
+  unreachable. The switch is invisible to the browser — same-origin cookies are preserved, so the
+  session survives (both backends share Supabase + JWT secrets).
+  - Conservative failover: GET/HEAD retry on any primary failure (connection error, 4s timeout, 5xx);
+    mutations (POST/PUT/PATCH/DELETE) retry **only** on connection-level errors that prove the
+    request never reached the primary (ECONNREFUSED/DNS/TLS) — never on timeout/5xx — to avoid
+    duplicate writes.
+  - Request body is buffered once and reused across both attempts.
+  - In-instance circuit breaker skips the primary for 30s after a connection failure (avoids paying
+    the timeout on every request during a sustained outage).
+  - Returns `502 { error: { code: 'BACKEND_UNAVAILABLE' } }` when both backends are unreachable.
+- **New env (Vercel)**: `API_BASE_URL_BACKUP` = public URL of the Render backup.
+
 ### Changed - 2026-06-11
 
 #### Dependencies

--- a/web/api/api-proxy.ts
+++ b/web/api/api-proxy.ts
@@ -1,29 +1,69 @@
 // /api/api-proxy.ts
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+/**
+ * Reverse proxy with transparent failover for the high-availability setup.
+ *
+ * The browser only ever talks to this serverless function (same-origin). It forwards to the
+ * MAIN backend (Railway, API_BASE_URL); if that is unreachable it retries the BACKUP backend
+ * (Render, API_BASE_URL_BACKUP). Cookies stay same-origin, so the switch is invisible to the
+ * client and the session survives (both backends share the same Supabase + JWT secrets).
+ *
+ * Failover policy is conservative to avoid duplicate writes:
+ *  - SAFE methods (GET/HEAD): fail over on any primary failure (connection error, timeout, 5xx).
+ *  - Mutations (POST/PUT/PATCH/DELETE): fail over ONLY when the request provably never reached
+ *    the primary (connection-level errors). A timeout or 5xx is NOT retried — the primary may
+ *    have already processed it.
+ */
+
+// How long to wait for the primary before giving up on it.
+const PRIMARY_TIMEOUT_MS = 4000;
+// After a connection-level primary failure, skip the primary for this long (warm-instance only).
+const CIRCUIT_OPEN_MS = 30_000;
+
+// Module-level circuit breaker. Persists only within a warm serverless instance, which is
+// enough to avoid paying the primary timeout on every request during a sustained outage.
+let primaryDownUntil = 0;
+
+const SAFE_METHODS = new Set(['GET', 'HEAD']);
+
+// fetch() error codes that mean the request never left this side / never reached the server.
+// Safe to retry on the backup even for mutations.
+const NOT_DELIVERED_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+function isNotDelivered(err: unknown): boolean {
+  const code = (err as { cause?: { code?: string } })?.cause?.code;
+  if (!code) return false;
+  if (NOT_DELIVERED_CODES.has(code)) return true;
+  // TLS/certificate handshake failures also happen before the request is sent.
+  if (code.startsWith('CERT_') || code.includes('SELF_SIGNED') || code.includes('UNABLE_TO_VERIFY')) {
+    return true;
+  }
+  return false;
+}
+
+const GATEWAY_STATUSES = new Set([502, 503, 504]);
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const targetBase =
+  const primaryBase =
     process.env.API_BASE_URL ||
     process.env.API_BASE_URL_STAGING ||
     process.env.API_BASE_URL_DEV ||
     'http://localhost:3000';
+  const backupBase = process.env.API_BASE_URL_BACKUP || '';
 
   const originalUrl = req.url || '/';
-
-  // ✅ Parsear correctamente
   const url = new URL(originalUrl, 'http://proxy.local'); // base dummy
   const path = url.pathname.replace(/^\/api\//, '');
-
-  // Opción A: reconstruir del objeto query (suele ser lo más predecible)
   const search = buildSearch(req);
-
-  // Opción B (alternativa): usar lo que vino tal cual en la URL:
-  // const search = url.search || '';
-
-  const targetUrl = `${stripTrailingSlash(targetBase)}/api/${path}${search}`;
-
-  // (opcional) te dejo un log útil para verificar
-  // console.log({ originalUrl, path, search, targetUrl });
+  const targetPath = `/api/${path}${search}`;
 
   const headers = new Headers();
   for (const [k, v] of Object.entries(req.headers)) {
@@ -33,18 +73,83 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
-  const init: RequestInit = { method: req.method, headers, redirect: 'manual' };
+  const method = (req.method || 'GET').toUpperCase();
+  const isSafe = SAFE_METHODS.has(method);
 
-  if (req.method && !['GET', 'HEAD'].includes(req.method)) {
+  // Buffer the body ONCE into a Buffer so it can be reused across primary + backup attempts.
+  let body: Buffer | undefined;
+  if (!['GET', 'HEAD'].includes(method)) {
     const chunks: Buffer[] = [];
-    for await (const c of (req as any as AsyncIterable<Buffer | string>)) {
+    for await (const c of req as unknown as AsyncIterable<Buffer | string>) {
       chunks.push(typeof c === 'string' ? Buffer.from(c) : c);
     }
-    init.body = Buffer.concat(chunks);
+    body = Buffer.concat(chunks);
   }
 
-  const resp = await fetch(targetUrl, init);
+  const buildInit = (signal?: AbortSignal): RequestInit => ({
+    method,
+    headers,
+    redirect: 'manual',
+    body,
+    signal,
+  });
 
+  // Try the primary unless the circuit is open (recent connection failure).
+  const circuitOpen = backupBase && Date.now() < primaryDownUntil;
+
+  if (!circuitOpen) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PRIMARY_TIMEOUT_MS);
+    try {
+      const resp = await fetch(`${stripTrailingSlash(primaryBase)}${targetPath}`, buildInit(controller.signal));
+      clearTimeout(timer);
+      primaryDownUntil = 0; // primary answered → close the circuit
+
+      // Gateway error from primary: fail over only for SAFE methods.
+      if (backupBase && isSafe && GATEWAY_STATUSES.has(resp.status)) {
+        const backupResp = await tryBackup(backupBase, targetPath, buildInit);
+        if (backupResp) return sendResponse(res, backupResp);
+      }
+      return sendResponse(res, resp);
+    } catch (err) {
+      clearTimeout(timer);
+      const notDelivered = isNotDelivered(err);
+      if (notDelivered) primaryDownUntil = Date.now() + CIRCUIT_OPEN_MS;
+
+      // Fail over to backup when allowed by the conservative policy.
+      const mayFailover = backupBase && (isSafe || notDelivered);
+      if (mayFailover) {
+        const backupResp = await tryBackup(backupBase, targetPath, buildInit);
+        if (backupResp) return sendResponse(res, backupResp);
+      }
+      return sendUnavailable(res);
+    }
+  }
+
+  // Circuit open: go straight to the backup.
+  const backupResp = await tryBackup(backupBase, targetPath, buildInit);
+  if (backupResp) return sendResponse(res, backupResp);
+  return sendUnavailable(res);
+}
+
+async function tryBackup(
+  backupBase: string,
+  targetPath: string,
+  buildInit: (signal?: AbortSignal) => RequestInit
+): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PRIMARY_TIMEOUT_MS);
+  try {
+    const resp = await fetch(`${stripTrailingSlash(backupBase)}${targetPath}`, buildInit(controller.signal));
+    return resp;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function sendResponse(res: VercelResponse, resp: Response): Promise<void> {
   res.status(resp.status);
 
   resp.headers.forEach((value, key) => {
@@ -53,7 +158,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   });
 
-  const anyHeaders = resp.headers as any;
+  const anyHeaders = resp.headers as unknown as {
+    getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
+  };
   const setCookies: string[] =
     (typeof anyHeaders.getSetCookie === 'function' && anyHeaders.getSetCookie()) ||
     (anyHeaders.raw && anyHeaders.raw()['set-cookie']) ||
@@ -62,6 +170,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const buf = Buffer.from(await resp.arrayBuffer());
   res.end(buf);
+}
+
+function sendUnavailable(res: VercelResponse): void {
+  res.status(502).setHeader('Content-Type', 'application/json');
+  res.end(
+    JSON.stringify({
+      error: {
+        code: 'BACKEND_UNAVAILABLE',
+        message: 'El servidor no está disponible en este momento. Reintente en unos segundos.',
+      },
+    })
+  );
 }
 
 function stripTrailingSlash(s: string) {


### PR DESCRIPTION
Duplicate the backend (Railway main + Render backup) sharing one Supabase DB, with failover handled at the Vercel proxy so it is invisible to the browser and keeps the session (same-origin cookies + shared JWT secrets).

- api: /health + /health/deep endpoints (public, pre-middleware)
- api: gate singleton jobs (archive/cleanup/keep-warm) behind ENABLE_BACKGROUND_JOBS; per-instance flush jobs still run everywhere
- api: keep-warm job pings the backup /health to avoid Render cold starts
- api: INSTANCE_NAME / ENABLE_BACKGROUND_JOBS / BACKUP_HEALTH_URL envs
- api: add `start: tsx src/index.ts` for production
- web: api-proxy.ts conservative failover (GET retries on any failure; mutations only on connection-level errors) + 30s circuit breaker
- render.yaml blueprint for the passive backup
- eslint: allow fetch/AbortController globals