### PR TITLE
style(web): larger calendar touch targets on mobile

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Web workspace are documented in this file.
 
 ## [Unreleased]
 
+### Changed - 2026-07-19 (Calendario mobile)
+
+#### Targets táctiles más grandes en el calendario
+- **`web/src/components/ui/calendar.tsx`**: en mobile los días pasan de 32px (`size-8`) a 40px (`size-10`), flechas de navegación a `size-9`, texto de días/encabezados/caption más grande y caption capitalizado. En `sm:` y superior mantiene el tamaño compacto anterior. Aplica a todos los date pickers (usan este componente base).
+- **`web/src/components/button/SelectDayToSearch.tsx`**: `collisionPadding={8}` en el `PopoverContent` para que el calendario no quede pegado al borde de la pantalla en viewports angostos.
+
 ### Added - 2026-07-19 (Jugadas con fecha pasada para admin+)
 
 #### Selector de fecha en Realizar Jugadas (solo roles no-cajero)

--- a/web/src/components/button/SelectDayToSearch.tsx
+++ b/web/src/components/button/SelectDayToSearch.tsx
@@ -69,7 +69,7 @@ export function SelectDayToSearch({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent className="w-auto p-0" align="start" collisionPadding={8}>
         <Suspense fallback={null}>
           <Calendar
             mode="single"

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -4,7 +4,6 @@ import { DayPicker } from 'react-day-picker';
 
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import dayjs from 'dayjs';
 
 function Calendar({
   className,
@@ -20,27 +19,28 @@ function Calendar({
         months: 'flex flex-col sm:flex-row gap-2',
         month: 'flex flex-col gap-4',
         caption: 'flex justify-center pt-1 relative items-center w-full',
-        caption_label: 'text-sm font-medium',
+        caption_label: 'text-base sm:text-sm font-medium capitalize',
         nav: 'flex items-center gap-1',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),
-          'size-7 bg-transparent p-0 opacity-50 hover:opacity-100'
+          'size-9 sm:size-7 bg-transparent p-0 opacity-50 hover:opacity-100'
         ),
         nav_button_previous: 'absolute left-1',
         nav_button_next: 'absolute right-1',
         table: 'w-full border-collapse space-x-1',
         head_row: 'flex justify-around',
-        head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
+        head_cell:
+          'text-muted-foreground rounded-md w-10 sm:w-8 font-normal text-sm sm:text-[0.8rem]',
         row: 'flex w-full mt-2',
         cell: cn(
-          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
+          'relative p-0 text-center text-base sm:text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
           props.mode === 'range'
             ? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
             : '[&:has([aria-selected])]:rounded-md'
         ),
         day: cn(
           buttonVariants({ variant: 'ghost' }),
-          'size-8 p-0 font-normal aria-selected:opacity-100'
+          'size-10 sm:size-8 p-0 font-normal aria-selected:opacity-100'
         ),
         day_range_start:
           'day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground',


### PR DESCRIPTION
Day cells 32px -> 40px, bigger nav arrows and text below the sm breakpoint; desktop keeps the compact layout. collisionPadding on the date-picker popover so it doesn't hug the screen edge on narrow viewports. Drop unused dayjs import.