### PR TITLE
style(make-plays): wrap header controls on small screens

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the Web workspace are documented in this file.
 
 ### Changed - 2026-07-19 (Calendario mobile)
 
+#### Header de Realizar Jugadas en pantallas chicas
+- **`web/src/features/make-plays/header-play-detail.tsx`**: el header no-cajero desbordaba en mobile y el select de Ticket quedaba fuera de pantalla. Ahora la fila hace `flex-wrap`: fecha + buscador de usuario en la primera línea (el nombre del cajero trunca con `min-w-0`), select de Ticket a ancho completo en la segunda. En `sm:`+ queda igual que antes.
+
 #### Targets táctiles más grandes en el calendario
 - **`web/src/components/ui/calendar.tsx`**: en mobile los días pasan de 32px (`size-8`) a 40px (`size-10`), flechas de navegación a `size-9`, texto de días/encabezados/caption más grande y caption capitalizado. En `sm:` y superior mantiene el tamaño compacto anterior. Aplica a todos los date pickers (usan este componente base).
 - **`web/src/components/button/SelectDayToSearch.tsx`**: `collisionPadding={8}` en el `PopoverContent` para que el calendario no quede pegado al borde de la pantalla en viewports angostos.

--- a/web/src/features/make-plays/header-play-detail.tsx
+++ b/web/src/features/make-plays/header-play-detail.tsx
@@ -101,9 +101,17 @@ const HeaderPlayDetail = () => {
   return (
     <HeaderSection title={' Realizar Jugadas'} className='gap-2'>
       {role !== USER_TYPE.CASHIER && (
-        <Flex className=" w-full  justify-start sm:justify-end gap-1 sm:gap-2 xl:gap-3 ">
-          <SelectDayToSearch selectedDay={dateParam} onDayChange={handleDayChange} />
-          <Flex className={'flex-row items-center justify-start gap-2 sm:gap-4 lg:gap-1.5 w-full sm:w-auto'}>
+        <Flex className=" w-full flex-wrap items-center justify-start sm:justify-end gap-1 sm:gap-2 xl:gap-3 ">
+          <SelectDayToSearch
+            selectedDay={dateParam}
+            onDayChange={handleDayChange}
+            className="shrink-0"
+          />
+          <Flex
+            className={
+              'flex-row items-center justify-start gap-2 sm:gap-4 lg:gap-1.5 flex-1 min-w-0 sm:flex-initial sm:w-auto'
+            }
+          >
             <Label htmlFor={'user'} className="hidden sm:inline text-xs sm:text-sm lg:text-base whitespace-nowrap"> Usuario</Label>
             <Input
               type={'number'}


### PR DESCRIPTION
Ticket select overflowed off-screen on mobile: header row now wraps — date picker + user search on the first line, ticket select full-width on the second. Desktop layout unchanged.