### PR TITLE
style(web): shrink mobile calendar to fit small viewports

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to the Web workspace are documented in this file.
 - **`web/src/features/make-plays/header-play-detail.tsx`**: el header no-cajero desbordaba en mobile y el select de Ticket quedaba fuera de pantalla. Ahora la fila hace `flex-wrap`: fecha + buscador de usuario en la primera línea (el nombre del cajero trunca con `min-w-0`), select de Ticket a ancho completo en la segunda. En `sm:`+ queda igual que antes.
 
 #### Targets táctiles más grandes en el calendario
-- **`web/src/components/ui/calendar.tsx`**: en mobile los días pasan de 32px (`size-8`) a 40px (`size-10`), flechas de navegación a `size-9`, texto de días/encabezados/caption más grande y caption capitalizado. En `sm:` y superior mantiene el tamaño compacto anterior. Aplica a todos los date pickers (usan este componente base).
-- **`web/src/components/button/SelectDayToSearch.tsx`**: `collisionPadding={8}` en el `PopoverContent` para que el calendario no quede pegado al borde de la pantalla en viewports angostos.
+- **`web/src/components/ui/calendar.tsx`**: en mobile los días pasan de 32px (`size-8`) a 36px (`size-9`), flechas de navegación a `size-8`, texto de días/encabezados/caption más grande y caption capitalizado. En `sm:` y superior mantiene el tamaño compacto anterior. Aplica a todos los date pickers (usan este componente base).
+- **`web/src/components/button/SelectDayToSearch.tsx`**: `collisionPadding={8}` y `max-w-[calc(100vw-16px)]` en el `PopoverContent` para que el calendario nunca desborde el viewport en pantallas angostas.
 
 ### Added - 2026-07-19 (Jugadas con fecha pasada para admin+)
 

--- a/web/src/components/button/SelectDayToSearch.tsx
+++ b/web/src/components/button/SelectDayToSearch.tsx
@@ -69,7 +69,11 @@ export function SelectDayToSearch({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start" collisionPadding={8}>
+      <PopoverContent
+        className="w-auto max-w-[calc(100vw-16px)] p-0"
+        align="start"
+        collisionPadding={8}
+      >
         <Suspense fallback={null}>
           <Calendar
             mode="single"

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -23,14 +23,14 @@ function Calendar({
         nav: 'flex items-center gap-1',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),
-          'size-9 sm:size-7 bg-transparent p-0 opacity-50 hover:opacity-100'
+          'size-8 sm:size-7 bg-transparent p-0 opacity-50 hover:opacity-100'
         ),
         nav_button_previous: 'absolute left-1',
         nav_button_next: 'absolute right-1',
         table: 'w-full border-collapse space-x-1',
         head_row: 'flex justify-around',
         head_cell:
-          'text-muted-foreground rounded-md w-10 sm:w-8 font-normal text-sm sm:text-[0.8rem]',
+          'text-muted-foreground rounded-md w-9 sm:w-8 font-normal text-sm sm:text-[0.8rem]',
         row: 'flex w-full mt-2',
         cell: cn(
           'relative p-0 text-center text-base sm:text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
@@ -40,7 +40,7 @@ function Calendar({
         ),
         day: cn(
           buttonVariants({ variant: 'ghost' }),
-          'size-10 sm:size-8 p-0 font-normal aria-selected:opacity-100'
+          'size-9 sm:size-8 p-0 font-normal aria-selected:opacity-100'
         ),
         day_range_start:
           'day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground',


### PR DESCRIPTION
Day cells 40px -> 36px, smaller nav arrows, and hard max-width clamp on the popover (100vw - 16px) so the calendar never overflows narrow screens.