### PR TITLE
fix(web): global table CSS broke calendar layout on mobile

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Web workspace are documented in this file.
 #### Targets táctiles más grandes en el calendario
 - **`web/src/components/ui/calendar.tsx`**: en mobile los días pasan de 32px (`size-8`) a 36px (`size-9`), flechas de navegación a `size-8`, texto de días/encabezados/caption más grande y caption capitalizado. En `sm:` y superior mantiene el tamaño compacto anterior. Aplica a todos los date pickers (usan este componente base).
 - **`web/src/components/button/SelectDayToSearch.tsx`**: `collisionPadding={8}` y `max-w-[calc(100vw-16px)]` en el `PopoverContent` para que el calendario nunca desborde el viewport en pantallas angostas.
+- **`web/src/styles/index.css`**: el CSS global de tablas (`th, td { padding: 8px !important }` + rayado de filas pares) pisaba el `p-0` del calendario — celdas de 52px, tabla de 364px que desbordaba viewports de 320px, y franjas azules en las semanas. Se agregó excepción scoped `.rdp th/td { padding: 0 !important }` y `.rdp tr:nth-child(even)` transparente. Verificado con Playwright a 320×480: tabla 252px, celdas 36px. Las tablas de datos no cambian.
 
 ### Added - 2026-07-19 (Jugadas con fecha pasada para admin+)
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -102,6 +102,17 @@
   tr:nth-child(even) {
     background-color: #007bff11;
   }
+
+  /* El calendario (react-day-picker) usa <table>: sin el padding global
+     las celdas quedan en 36px y la tabla entra en viewports de 320px.
+     También se anula el rayado de filas pares de las tablas de datos. */
+  .rdp th,
+  .rdp td {
+    padding: 0 !important;
+  }
+  .rdp tr:nth-child(even) {
+    background-color: transparent;
+  }
   thead {
     background-color: var(--bg-card);
     height: 36px;


### PR DESCRIPTION
th/td { padding: 8px !important } (meant for data tables) overrode the calendar's p-0 — 52px cells made the month table 364px wide, overflowing 320px screens — and tr:nth-child(even) striped the week rows. Scoped .rdp exception zeroes the padding and striping for react-day-picker tables only. Verified headless at 320x480: table 252px, cells 36px.